### PR TITLE
Bite-sized lessons with diagnostic calibration

### DIFF
--- a/backend/src/app/agents/activity_creator.py
+++ b/backend/src/app/agents/activity_creator.py
@@ -10,22 +10,28 @@ activity_creator = Agent(
     retries=2,
     system_prompt=(
         "You are an expert activity designer for educational courses. Given an activity seed "
-        "(type, prompt, expected evidence) and the lesson's mastery criteria, create a complete "
-        "practice activity.\n\n"
-        "Requirements:\n"
-        "- instructions: Clear, actionable instructions (min 50 chars) telling the learner "
-        "exactly what to do, including constraints (length, format, required components)\n"
-        "- prompt: The specific question or task (min 20 chars)\n"
-        "- scoring_rubric: 3-6 specific, gradeable criteria that map to the mastery criteria. "
-        "Each should be checkable (e.g., 'Includes at least 3 examples with explanations')\n"
-        "- hints: 2-5 scaffolding hints that guide without giving the answer\n\n"
-        "The activity should directly test the learning objective. Make it challenging but "
-        "achievable. Tailor to the learner's profile if provided.\n\n"
-        "IMPORTANT — Domain transfer: The activity seed shows the TOPIC and SKILL to test, "
-        "but you MUST set the activity in a DIFFERENT real-world domain/scenario than the one "
-        "in the seed. For example, if the seed uses a 'user profile' scenario, use something "
-        "unrelated like a 'weather tracker' or 'recipe book'. This forces learners to transfer "
-        "knowledge rather than copy the worked example from the lesson."
+        "(type, prompt, expected evidence), mastery criteria, and context about the activity's "
+        "role and difficulty, create a complete practice activity.\n\n"
+        "You will be given a ROLE (focused or capstone) and a DIFFICULTY LEVEL (1-3).\n\n"
+        "FOCUSED activities (difficulty 1-3):\n"
+        "  Level 1 — Introductory: Basic recognition or definition. "
+        "1-2 sentence prompt. Rubric: 1-2 criteria. Hints: 2 generous hints. "
+        "Activity type: short-answer or definition.\n"
+        "  Level 2 — Applied: Demonstrate understanding in context. "
+        "Rubric: 2-3 criteria. Hints: 1-2. Activity type: example or brief explanation.\n"
+        "  Level 3 — Pre-mastery: Synthesis and analysis. "
+        "Rubric: 3-4 criteria. Hints: 1-2. Requires more complete response.\n\n"
+        "CAPSTONE activities (always the hardest):\n"
+        "  Integrative — apply ALL mastery criteria in a realistic scenario. "
+        "Rubric: 3-6 criteria mapping to mastery criteria. Hints: 2-4. "
+        "Prompt must require concrete, multi-part evidence.\n\n"
+        "General requirements:\n"
+        "- instructions: Clear, actionable instructions telling the learner exactly what to do\n"
+        "- prompt: The specific question or task\n"
+        "- scoring_rubric: Specific, gradeable criteria (e.g., 'Includes 2+ concrete examples')\n"
+        "- hints: Scaffolding hints that guide without giving the answer\n\n"
+        "IMPORTANT — Domain transfer: Set the activity in a DIFFERENT real-world scenario than "
+        "the lesson's worked example. This forces knowledge transfer, not copying."
     ),
 )
 
@@ -36,14 +42,26 @@ async def run_activity_creator(
     objective: str,
     mastery_criteria: list[str],
     learner_profile: dict | None = None,
+    difficulty_level: int = 3,
+    lesson_role: str = "capstone",
+    concept_focus: str | None = None,
 ) -> ActivitySpecOutput:
     prompt = (
         f"Learning objective: {objective}\n\n"
-        f"Mastery criteria:\n"
+        f"Activity role: {lesson_role.upper()}\n"
+        f"Difficulty level: {difficulty_level} (1=intro, 2=applied, 3=pre-mastery / capstone)\n"
+    )
+    if concept_focus:
+        prompt += f"Concept this activity focuses on: {concept_focus}\n"
+
+    prompt += (
+        f"\nMastery criteria:\n"
         + "\n".join(f"- {c}" for c in mastery_criteria)
         + f"\n\nActivity seed:\n{activity_seed.model_dump_json(indent=2)}\n"
     )
     if learner_profile:
         prompt += f"\nLearner profile: {learner_profile}\n"
 
-    return await run_agent(ctx, activity_creator, "activity_creator", prompt, model=settings.fast_model)
+    return await run_agent(
+        ctx, activity_creator, "activity_creator", prompt, model=settings.fast_model
+    )

--- a/backend/src/app/agents/diagnostic.py
+++ b/backend/src/app/agents/diagnostic.py
@@ -1,0 +1,87 @@
+from pydantic_ai import Agent
+
+from app.agents.logging import AgentContext, run_agent
+from app.config import settings
+from app.schemas.diagnostic import DiagnosticAnalysis, DiagnosticSpec
+
+diagnostic_creator = Agent(
+    output_type=DiagnosticSpec,
+    retries=2,
+    system_prompt=(
+        "You are an expert learning designer creating a pre-course diagnostic.\n\n"
+        "Your goal is to reveal the learner's EXISTING knowledge before any content is generated. "
+        "This diagnostic will be used to calibrate lesson depth, activity difficulty, and rigor.\n\n"
+        "Design 3-5 open-ended questions that:\n"
+        "- Probe familiarity with core concepts (not test them — ask what they already know)\n"
+        "- Surface prior practical experience ('Have you ever...', 'How would you approach...')\n"
+        "- Reveal mental models and misconceptions\n"
+        "- Are conversational and non-intimidating (this is not an exam)\n\n"
+        "For each question, provide a rationale explaining what knowledge gap or "
+        "strength it is designed to surface.\n\n"
+        "Questions must be directly relevant to the course objectives provided. "
+        "Do not ask about unrelated topics."
+    ),
+)
+
+diagnostic_analyzer = Agent(
+    output_type=DiagnosticAnalysis,
+    retries=2,
+    system_prompt=(
+        "You are an expert learning designer analyzing a learner's diagnostic responses.\n\n"
+        "Based on the course objectives and the learner's answers, produce a concise analysis that:\n\n"
+        "1. baseline_level: Classify overall knowledge as 'novice', 'intermediate', or 'advanced'. "
+        "Use clear evidence from their answers to justify the classification.\n\n"
+        "2. concept_gaps: List specific concepts from the objectives that the learner clearly lacks "
+        "knowledge of. Be precise — name the concepts, not vague areas.\n\n"
+        "3. strength_areas: List concepts the learner already demonstrates solid understanding of. "
+        "These may be covered briefly since they are foundations already in place.\n\n"
+        "4. rigor_guidance: Write 2-4 sentences of actionable guidance for the generation agents. "
+        "How challenging should activities be? What level of assumed knowledge is appropriate? "
+        "What examples or contexts resonate with this learner?\n\n"
+        "5. focus_recommendations: List which objectives deserve more depth and time given the gaps. "
+        "Be specific about why each needs extra focus.\n\n"
+        "Be honest and specific. Generic analysis wastes the diagnostic data."
+    ),
+)
+
+
+async def run_diagnostic_creator(
+    ctx: AgentContext,
+    objectives: list[str],
+    course_description: str,
+    learner_profile: dict | None = None,
+) -> DiagnosticSpec:
+    prompt = (
+        f"Course description: {course_description}\n\n"
+        f"Learning objectives:\n"
+        + "\n".join(f"- {o}" for o in objectives)
+    )
+    if learner_profile:
+        prompt += f"\n\nLearner profile: {learner_profile}"
+
+    return await run_agent(
+        ctx, diagnostic_creator, "diagnostic_creator", prompt, model=settings.fast_model
+    )
+
+
+async def run_diagnostic_analyzer(
+    ctx: AgentContext,
+    objectives: list[str],
+    course_description: str,
+    diagnostic_spec: dict,
+    responses: list[dict],
+) -> DiagnosticAnalysis:
+    questions_and_answers = "\n\n".join(
+        f"Q: {r.get('question', '')}\nA: {r.get('answer', '(no answer)')}"
+        for r in responses
+    )
+    prompt = (
+        f"Course description: {course_description}\n\n"
+        f"Learning objectives:\n"
+        + "\n".join(f"- {o}" for o in objectives)
+        + f"\n\nDiagnostic Q&A:\n{questions_and_answers}"
+    )
+
+    return await run_agent(
+        ctx, diagnostic_analyzer, "diagnostic_analyzer", prompt, model=settings.fast_model
+    )

--- a/backend/src/app/agents/lesson_planner.py
+++ b/backend/src/app/agents/lesson_planner.py
@@ -2,40 +2,41 @@ from pydantic_ai import Agent
 
 from app.agents.logging import AgentContext, run_agent
 from app.config import settings
-from app.schemas.lesson import LessonPlanOutput
+from app.schemas.lesson import ObjectivePlanOutput
 
 lesson_planner = Agent(
-    output_type=LessonPlanOutput,
+    output_type=ObjectivePlanOutput,
     retries=2,
     system_prompt=(
-        "You are an expert instructional designer creating a lesson plan using backward design.\n\n"
-        "Follow this three-step reasoning order when filling out the plan:\n\n"
-        "STEP 1 — Define the finish line (mastery_criteria):\n"
-        "  What does mastery of this objective look like? Write 2-6 rubric-style checks "
-        "that a reviewer could use to determine whether the learner truly got it. "
-        "Be specific and measurable.\n\n"
-        "STEP 2 — Design the evidence of mastery (suggested_activity):\n"
-        "  What practice activity would require the learner to demonstrate all the mastery "
-        "criteria? Specify the activity type, a clear prompt, and 2-5 pieces of evidence "
-        "a successful submission would contain. The activity must directly exercise the "
-        "mastery criteria — not just recall facts.\n\n"
-        "STEP 3 — Plan the path to get there (lesson_outline):\n"
-        "  Now that you know exactly what the learner must be able to do, design a 3-10 "
-        "step lesson outline that closes the gap. Each step should build the knowledge or "
-        "skill the learner will need to succeed at the activity. Ask yourself: after "
-        "completing this outline, could a learner attempt the activity and plausibly meet "
-        "every mastery criterion? If not, revise.\n\n"
-        "Other fields:\n"
-        "- lesson_title: A clear, specific title for this lesson (not the course title)\n"
-        "- learning_objective: Restate the objective as a clear, measurable outcome\n"
-        "- key_concepts: 2-8 core concepts the lesson must cover\n\n"
-        "The plan must be specific enough that downstream agents can produce aligned content "
-        "without guessing. Tailor the plan to the learner's profile if provided.\n\n"
-        "IMPORTANT — Scope control: You will receive the full list of course objectives. "
-        "Your lesson must cover ONLY the assigned objective. You may briefly mention related "
-        "topics to give context (e.g., a single sentence noting they exist), but do NOT "
-        "teach, define, or provide tables/examples for concepts that belong to a different "
-        "objective. Those will be covered in their own lessons."
+        "You are an expert instructional designer planning ALL lessons for a single learning objective.\n\n"
+        "You will produce an ObjectivePlanOutput that contains:\n"
+        "  - 2-3 focused sub-lesson seeds (one per key concept, escalating difficulty)\n"
+        "  - 1 capstone seed (integrative, hardest)\n\n"
+        "Follow this reasoning order:\n\n"
+        "STEP 1 — Define mastery (mastery_criteria):\n"
+        "  What does full mastery of this objective look like? Write 2-6 specific, "
+        "measurable criteria a reviewer could use to confirm the learner truly got it.\n\n"
+        "STEP 2 — Identify key concepts (key_concepts):\n"
+        "  Break the objective into 2-4 distinct concepts that must be learned in sequence. "
+        "Each concept will become one focused sub-lesson. Keep concepts narrow and concrete.\n\n"
+        "STEP 3 — Design the capstone (capstone_seed):\n"
+        "  Design one integrative activity that requires the learner to apply ALL key concepts "
+        "and demonstrate ALL mastery criteria. This is the final gate for this objective. "
+        "The prompt must require concrete evidence — not just recall.\n\n"
+        "STEP 4 — Design focused sub-lessons (sub_lesson_seeds):\n"
+        "  For each key concept (in order), create one SubLessonSeed:\n"
+        "  - sub_lesson_index: 0-based index (0, 1, 2)\n"
+        "  - title: Clear, specific title for this lesson\n"
+        "  - concept_focus: The exact concept this lesson covers (matches key_concepts[i])\n"
+        "  - activity_seed: A focused practice activity for THIS concept only\n"
+        "  - difficulty_level: 1 for the first sub-lesson (introductory), increasing by 1 "
+        "each sub-lesson (so 2nd = level 2, 3rd = level 3). Difficulty 1 = basic recognition "
+        "or definition; 2 = applied understanding; 3 = near-mastery synthesis.\n\n"
+        "Sub-lesson activities are attempt-gated (any attempt allows advancing). "
+        "The capstone is mastery-gated (requires score ≥70). Design activities accordingly — "
+        "sub-lessons scaffold toward the capstone, not replace it.\n\n"
+        "SCOPE CONTROL: You will receive all course objectives. Your plan covers ONLY the "
+        "assigned objective. Do not teach concepts from other objectives."
     ),
 )
 
@@ -46,21 +47,31 @@ async def run_lesson_planner(
     course_description: str,
     all_objectives: list[str] | None = None,
     learner_profile: dict | None = None,
-) -> LessonPlanOutput:
+    diagnostic_analysis: dict | None = None,
+) -> ObjectivePlanOutput:
     prompt = (
         f"Course description: {course_description}\n\n"
-        f"Learning objective for THIS lesson: {objective}\n"
+        f"Learning objective to plan: {objective}\n"
     )
     if all_objectives:
         other = [o for o in all_objectives if o != objective]
         if other:
             prompt += (
-                "\nOther objectives in this course (DO NOT teach these, "
-                "they have their own lessons):\n"
+                "\nOther objectives in this course (DO NOT teach these):\n"
                 + "\n".join(f"- {o}" for o in other)
                 + "\n"
             )
+    if diagnostic_analysis:
+        prompt += (
+            f"\nLearner diagnostic analysis:\n"
+            f"  Baseline level: {diagnostic_analysis.get('baseline_level', 'unknown')}\n"
+            f"  Concept gaps: {', '.join(diagnostic_analysis.get('concept_gaps', []))}\n"
+            f"  Strength areas: {', '.join(diagnostic_analysis.get('strength_areas', []))}\n"
+            f"  Rigor guidance: {diagnostic_analysis.get('rigor_guidance', '')}\n"
+        )
     if learner_profile:
         prompt += f"\nLearner profile: {learner_profile}\n"
 
-    return await run_agent(ctx, lesson_planner, "lesson_planner", prompt, model=settings.fast_model)
+    return await run_agent(
+        ctx, lesson_planner, "lesson_planner", prompt, model=settings.fast_model
+    )

--- a/backend/src/app/agents/lesson_writer.py
+++ b/backend/src/app/agents/lesson_writer.py
@@ -1,29 +1,34 @@
 from pydantic_ai import Agent
 
 from app.agents.logging import AgentContext, run_agent
-from app.schemas.lesson import LessonContentOutput, LessonPlanOutput
+from app.config import settings
+from app.schemas.lesson import LessonContentOutput, SubLessonSeed
 
 lesson_writer = Agent(
     output_type=LessonContentOutput,
     retries=2,
     system_prompt=(
-        "You are an expert educational content writer. Given a lesson plan, write a complete "
-        "lesson in Markdown.\n\n"
-        "Requirements for the lesson body:\n"
-        "- Start with a clear statement of the learning objective\n"
-        "- Explain why this topic matters (real-world relevance)\n"
-        "- Walk through the key concepts with clear steps and explanations\n"
-        "- Include at least one concrete, worked example\n"
-        "- End with a brief recap that ties back to the objective\n"
-        "- Use Markdown headings (##, ###), lists, and code blocks where appropriate\n"
-        "- Write in a clear, engaging voice — teach, don't lecture\n"
-        "- Minimum 200 characters for the lesson body\n"
-        "- The lesson plan includes a suggested_activity and mastery_criteria. By the end of "
-        "the lesson, the learner should have everything they need to attempt the activity and "
-        "plausibly meet each mastery criterion. Make this explicit: use worked examples that "
-        "mirror the skill demands of the activity, and close with a note signalling what the "
-        "learner is now ready to do (e.g., 'You're now ready to try [activity type]').\n\n"
-        "Also provide 3-6 concise key takeaways.\n\n"
+        "You are an expert educational content writer. You write focused, bite-sized lessons.\n\n"
+        "You will be told whether you are writing a FOCUSED sub-lesson or a CAPSTONE lesson. "
+        "The requirements differ significantly:\n\n"
+        "FOCUSED sub-lesson:\n"
+        "- Cover ONE concept only — the concept_focus provided. Stay tightly scoped.\n"
+        "- Length: 2-4 paragraphs. Short and dense, not padded.\n"
+        "- Include ONE concrete worked example that directly mirrors the activity the learner "
+        "will attempt immediately after reading.\n"
+        "- Close with a sentence signalling readiness: 'You're now ready to practice [concept].'\n"
+        "- Key takeaways: 2-3 short bullet points.\n"
+        "- Minimum 100 characters for the lesson body.\n\n"
+        "CAPSTONE lesson:\n"
+        "- Synthesize ALL key concepts covered in the previous sub-lessons.\n"
+        "- Length: 4-8 paragraphs.\n"
+        "- Show how the concepts connect and reinforce each other.\n"
+        "- Include a worked example that integrates multiple concepts.\n"
+        "- Close with: 'You're now ready for the capstone challenge.'\n"
+        "- Key takeaways: 3-4 bullet points.\n"
+        "- Minimum 100 characters for the lesson body.\n\n"
+        "Use Markdown (##, ###, lists, code blocks) as appropriate. "
+        "Write in a clear, engaging voice. "
         "Tailor tone, examples, and difficulty to the learner's profile if provided."
     ),
 )
@@ -31,15 +36,45 @@ lesson_writer = Agent(
 
 async def run_lesson_writer(
     ctx: AgentContext,
-    lesson_plan: LessonPlanOutput,
+    seed: SubLessonSeed | None,
+    objective: str,
     course_description: str,
     learner_profile: dict | None = None,
+    lesson_role: str = "focused",
+    key_concepts: list[str] | None = None,
+    mastery_criteria: list[str] | None = None,
 ) -> LessonContentOutput:
+    """Write lesson content for one sub-lesson or the capstone.
+
+    Args:
+        seed: SubLessonSeed for focused lessons; None for capstone.
+        lesson_role: "focused" or "capstone"
+        key_concepts: All concepts (passed for capstone context)
+        mastery_criteria: All mastery criteria (passed for capstone context)
+    """
     prompt = (
         f"Course description: {course_description}\n\n"
-        f"Lesson plan:\n{lesson_plan.model_dump_json(indent=2)}\n"
+        f"Learning objective: {objective}\n\n"
+        f"Lesson role: {lesson_role.upper()}\n\n"
     )
+
+    if lesson_role == "focused" and seed is not None:
+        prompt += (
+            f"Concept to cover: {seed.concept_focus}\n"
+            f"Lesson title: {seed.title}\n"
+            f"Difficulty level: {seed.difficulty_level} (1=intro, 2=applied, 3=pre-mastery)\n"
+            f"Activity the learner will attempt after this lesson:\n"
+            f"  Type: {seed.activity_seed.activity_type}\n"
+            f"  Prompt: {seed.activity_seed.prompt}\n"
+        )
+    else:
+        prompt += "This is the CAPSTONE lesson — synthesize all concepts.\n"
+        if key_concepts:
+            prompt += "Key concepts covered in sub-lessons:\n" + "\n".join(f"- {c}" for c in key_concepts) + "\n"
+        if mastery_criteria:
+            prompt += "Mastery criteria the learner must demonstrate:\n" + "\n".join(f"- {c}" for c in mastery_criteria) + "\n"
+
     if learner_profile:
         prompt += f"\nLearner profile: {learner_profile}\n"
 
-    return await run_agent(ctx, lesson_writer, "lesson_writer", prompt)
+    return await run_agent(ctx, lesson_writer, "lesson_writer", prompt, model=settings.default_model)

--- a/backend/src/app/db/migrations/versions/3d50862c3ed3_bite_sized_lessons.py
+++ b/backend/src/app/db/migrations/versions/3d50862c3ed3_bite_sized_lessons.py
@@ -1,0 +1,58 @@
+"""bite_sized_lessons
+
+Revision ID: 3d50862c3ed3
+Revises: 1c86f25998a1
+Create Date: 2026-03-03 16:39:58.509273
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3d50862c3ed3'
+down_revision: Union[str, Sequence[str], None] = '1c86f25998a1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # lessons: sub_lesson_index, lesson_role, lesson_title
+    op.add_column('lessons', sa.Column(
+        'sub_lesson_index', sa.Integer(), nullable=False, server_default='0'
+    ))
+    op.add_column('lessons', sa.Column(
+        'lesson_role', sa.String(20), nullable=False, server_default='capstone'
+    ))
+    op.add_column('lessons', sa.Column(
+        'lesson_title', sa.String(200), nullable=True
+    ))
+
+    # course_instances: diagnostic columns
+    op.add_column('course_instances', sa.Column(
+        'diagnostic_spec',
+        postgresql.JSONB(astext_type=sa.Text()),
+        nullable=True,
+    ))
+    op.add_column('course_instances', sa.Column(
+        'diagnostic_responses',
+        postgresql.JSONB(astext_type=sa.Text()),
+        nullable=True,
+    ))
+    op.add_column('course_instances', sa.Column(
+        'diagnostic_analysis',
+        postgresql.JSONB(astext_type=sa.Text()),
+        nullable=True,
+    ))
+
+
+def downgrade() -> None:
+    op.drop_column('course_instances', 'diagnostic_analysis')
+    op.drop_column('course_instances', 'diagnostic_responses')
+    op.drop_column('course_instances', 'diagnostic_spec')
+    op.drop_column('lessons', 'lesson_title')
+    op.drop_column('lessons', 'lesson_role')
+    op.drop_column('lessons', 'sub_lesson_index')

--- a/backend/src/app/db/models.py
+++ b/backend/src/app/db/models.py
@@ -93,6 +93,9 @@ class CourseInstance(Base):
     input_objectives: Mapped[list] = mapped_column(JSONB, default=list)
     generated_description: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(String(30), default="draft")
+    diagnostic_spec: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    diagnostic_responses: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    diagnostic_analysis: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utcnow, onupdate=utcnow
@@ -102,7 +105,7 @@ class CourseInstance(Base):
     lessons: Mapped[list["Lesson"]] = relationship(
         back_populates="course_instance",
         cascade="all, delete-orphan",
-        order_by="Lesson.objective_index",
+        order_by="Lesson.objective_index, Lesson.sub_lesson_index",
     )
     assessments: Mapped[list["Assessment"]] = relationship(
         back_populates="course_instance", cascade="all, delete-orphan"
@@ -120,6 +123,9 @@ class Lesson(Base):
         String(36), ForeignKey("course_instances.id", ondelete="CASCADE"), nullable=False
     )
     objective_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    sub_lesson_index: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    lesson_role: Mapped[str] = mapped_column(String(20), nullable=False, default="capstone")
+    lesson_title: Mapped[str | None] = mapped_column(String(200), nullable=True)
     lesson_content: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(String(20), default="locked")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)

--- a/backend/src/app/routers/activities.py
+++ b/backend/src/app/routers/activities.py
@@ -116,6 +116,8 @@ async def submit_activity(
     await db.flush()
     await db.commit()
 
+    is_capstone = lesson.lesson_role in ("capstone", None)  # null = legacy capstone
+
     kickoff_background_task(
         key,
         review_activity_background(
@@ -126,6 +128,7 @@ async def submit_activity(
             activity_prompt=spec.get("prompt", ""),
             scoring_rubric=spec.get("scoring_rubric", []),
             course_id=course.id,
+            is_capstone=is_capstone,
         ),
         conflict_detail="Review already in progress",
     )

--- a/backend/src/app/routers/courses.py
+++ b/backend/src/app/routers/courses.py
@@ -4,10 +4,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sse_starlette.sse import EventSourceResponse
 
+from app.agents.diagnostic import run_diagnostic_analyzer
+from app.agents.logging import AgentContext
 from app.auth.dependencies import get_current_user
 from app.db.models import CourseInstance, Lesson, User
 from app.db.session import get_db_session
-from app.services.generation import generate_course_background
+from app.schemas.diagnostic import DiagnosticSubmitRequest
+from app.services.generation import generate_course_background, generate_diagnostic
 from app.services.generation_tracker import is_running
 from app.services.sse import kickoff_background_task, sse_event_generator
 from app.schemas.course import CourseCreateRequest, CourseListItem
@@ -55,15 +58,89 @@ async def trigger_generation(
             detail=f"Course must be in 'draft' or 'generation_failed' state, got '{course.status}'",
         )
 
-    profile_dict = user.learner_profile.to_agent_dict() if user.learner_profile else None
+    # Transition to awaiting_diagnostic and commit before running LLM call
+    await transition_course(db, course, "awaiting_diagnostic")
+    await db.commit()
 
-    # Capture plain data for the background task
-    objectives = list(course.input_objectives)
-    description = course.input_description or ""
+    # Generate diagnostic questions synchronously (fast model, quick)
+    diagnostic_spec = await generate_diagnostic(course_id, user.id)
 
-    # Transition to generating and commit so the status is visible
+    return {
+        "id": course.id,
+        "status": "awaiting_diagnostic",
+        "diagnostic_spec": diagnostic_spec,
+    }
+
+
+@router.get("/{course_id}/diagnostic", response_model=dict)
+async def get_diagnostic(
+    course_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+):
+    result = await db.execute(
+        select(CourseInstance)
+        .where(CourseInstance.id == course_id, CourseInstance.user_id == user.id)
+    )
+    course = result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=404, detail="Course not found")
+
+    return {
+        "status": course.status,
+        "diagnostic_spec": course.diagnostic_spec,
+    }
+
+
+@router.post("/{course_id}/diagnostic/submit", response_model=dict)
+async def submit_diagnostic(
+    course_id: str,
+    req: DiagnosticSubmitRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db_session),
+):
+    result = await db.execute(
+        select(CourseInstance)
+        .where(CourseInstance.id == course_id, CourseInstance.user_id == user.id)
+    )
+    course = result.scalar_one_or_none()
+    if not course:
+        raise HTTPException(status_code=404, detail="Course not found")
+
+    if course.status != "awaiting_diagnostic":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Course must be in 'awaiting_diagnostic' state, got '{course.status}'",
+        )
+
+    # Store responses and commit
+    course.diagnostic_responses = req.responses
+    await db.flush()
+    await db.commit()
+
+    # Analyze responses synchronously (fast model)
+    ctx = AgentContext(db=db, user_id=user.id, course_instance_id=course_id)
+    analysis = await run_diagnostic_analyzer(
+        ctx,
+        objectives=list(course.input_objectives),
+        course_description=course.input_description or "",
+        diagnostic_spec=course.diagnostic_spec or {},
+        responses=req.responses,
+    )
+
+    # Store analysis, transition to generating, commit
+    result = await db.execute(
+        select(CourseInstance).where(CourseInstance.id == course_id)
+    )
+    course = result.scalar_one()
+    course.diagnostic_analysis = analysis.model_dump()
     await transition_course(db, course, "generating")
     await db.commit()
+
+    profile_dict = user.learner_profile.to_agent_dict() if user.learner_profile else None
+    objectives = list(course.input_objectives)
+    description = course.input_description or ""
+    diagnostic_analysis = analysis.model_dump()
 
     kickoff_background_task(
         course_id,
@@ -73,6 +150,7 @@ async def trigger_generation(
             objectives=objectives,
             description=description,
             learner_profile=profile_dict,
+            diagnostic_analysis=diagnostic_analysis,
         ),
         conflict_detail="Generation already in progress",
     )
@@ -99,26 +177,38 @@ async def generation_stream(
     if not course:
         raise HTTPException(status_code=404, detail="Course not found")
 
-    # Build catchup events from lessons already in DB
-    existing_lessons = sorted(course.lessons, key=lambda l: l.objective_index)
+    # Build catchup events from lessons already in DB (one lesson_planned per objective)
+    seen_objectives: set[int] = set()
     catchup_events: list[dict] = []
-    for lesson in existing_lessons:
-        idx = lesson.objective_index
-        catchup_events.append({
-            "event": "lesson_planned",
-            "data": {"objective_index": idx, "lesson_title": None, "skipped": True},
-        })
+    for lesson in sorted(course.lessons, key=lambda l: (l.objective_index, l.sub_lesson_index)):
+        obj_idx = lesson.objective_index
+        if obj_idx not in seen_objectives:
+            seen_objectives.add(obj_idx)
+            catchup_events.append({
+                "event": "lesson_planned",
+                "data": {
+                    "objective_index": obj_idx,
+                    "objective_title": lesson.lesson_title,
+                    "skipped": True,
+                },
+            })
         if lesson.lesson_content is not None:
             catchup_events.append({
                 "event": "lesson_written",
-                "data": {"objective_index": idx, "skipped": True},
+                "data": {
+                    "objective_index": obj_idx,
+                    "sub_lesson_index": lesson.sub_lesson_index,
+                    "skipped": True,
+                },
             })
         if lesson.activities:
             catchup_events.append({
                 "event": "activity_created",
                 "data": {
-                    "objective_index": idx,
+                    "objective_index": obj_idx,
+                    "sub_lesson_index": lesson.sub_lesson_index,
                     "activity_id": lesson.activities[0].id,
+                    "lesson_role": lesson.lesson_role,
                     "skipped": True,
                 },
             })
@@ -142,7 +232,7 @@ async def generation_stream(
         is_done=is_done,
         done_event={
             "event": "generation_complete",
-            "data": {"course_id": course_id, "lesson_count": len(existing_lessons)},
+            "data": {"course_id": course_id, "lesson_count": len(course.lessons)},
         },
         terminal_events={"generation_complete"},
         on_timeout_fallback=_timeout_fallback,
@@ -211,10 +301,14 @@ async def get_course(
         input_objectives=course.input_objectives,
         generated_description=course.generated_description,
         status=course.status,
+        diagnostic_spec=course.diagnostic_spec,
         lessons=[
             LessonResponse(
                 id=l.id,
                 objective_index=l.objective_index,
+                sub_lesson_index=l.sub_lesson_index,
+                lesson_role=l.lesson_role,
+                lesson_title=l.lesson_title,
                 lesson_content=l.lesson_content,
                 status=l.status,
                 activity=ActivitySummary(

--- a/backend/src/app/schemas/activity.py
+++ b/backend/src/app/schemas/activity.py
@@ -7,8 +7,8 @@ class ActivitySpecOutput(BaseModel):
     activity_type: str
     instructions: str = Field(min_length=50)
     prompt: str = Field(min_length=20)
-    scoring_rubric: list[str] = Field(min_length=3, max_length=6)
-    hints: list[str] = Field(min_length=2, max_length=5)
+    scoring_rubric: list[str] = Field(min_length=1, max_length=6)
+    hints: list[str] = Field(min_length=1, max_length=5)
 
 
 class ActivitySubmitRequest(BaseModel):

--- a/backend/src/app/schemas/course.py
+++ b/backend/src/app/schemas/course.py
@@ -20,6 +20,7 @@ class CourseResponse(BaseModel):
     input_objectives: list
     generated_description: str | None
     status: str
+    diagnostic_spec: dict | None = None
     lessons: list["LessonResponse"] = []
     assessments: list["AssessmentSummary"] = []
 
@@ -29,6 +30,9 @@ class CourseResponse(BaseModel):
 class LessonResponse(BaseModel):
     id: str
     objective_index: int
+    sub_lesson_index: int = 0
+    lesson_role: str = "capstone"  # "focused" | "capstone"
+    lesson_title: str | None = None
     lesson_content: str | None
     status: str
     activity: "ActivitySummary | None" = None

--- a/backend/src/app/schemas/diagnostic.py
+++ b/backend/src/app/schemas/diagnostic.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel, Field
+
+
+class DiagnosticQuestion(BaseModel):
+    """One diagnostic question probing the learner's baseline knowledge."""
+
+    question: str
+    rationale: str  # why this reveals relevant baseline knowledge
+
+
+class DiagnosticSpec(BaseModel):
+    """Output from the diagnostic_creator agent."""
+
+    questions: list[DiagnosticQuestion] = Field(min_length=3, max_length=5)
+
+
+class DiagnosticSubmitRequest(BaseModel):
+    """Learner's answers to the diagnostic questions."""
+
+    responses: list[dict]  # [{question: str, answer: str}]
+
+
+class DiagnosticAnalysis(BaseModel):
+    """Output from the diagnostic_analyzer agent."""
+
+    baseline_level: str  # "novice" | "intermediate" | "advanced"
+    concept_gaps: list[str]  # topics the learner clearly lacks
+    strength_areas: list[str]  # topics the learner already knows well
+    rigor_guidance: str  # overall instruction for downstream generation agents
+    focus_recommendations: list[str]  # which objectives need more depth/time

--- a/backend/src/app/schemas/lesson.py
+++ b/backend/src/app/schemas/lesson.py
@@ -1,28 +1,40 @@
 from pydantic import BaseModel, Field
 
 
-class LessonPlanOutput(BaseModel):
-    """Output from the lesson_planner agent."""
-
-    lesson_title: str
-    learning_objective: str
-    key_concepts: list[str] = Field(min_length=2, max_length=8)
-    mastery_criteria: list[str] = Field(min_length=2, max_length=6)
-    suggested_activity: "ActivitySeed"
-    lesson_outline: list[str] = Field(min_length=3, max_length=10)
-
-
 class ActivitySeed(BaseModel):
-    """Seed for the activity_creator agent, produced by lesson_planner."""
+    """Seed for one activity, used as input to the activity_creator agent."""
 
     activity_type: str
     prompt: str
     expected_evidence: list[str] = Field(min_length=2, max_length=5)
 
 
+class SubLessonSeed(BaseModel):
+    """Seed for one focused sub-lesson within an objective."""
+
+    sub_lesson_index: int  # 0-based within objective
+    title: str  # shown in sidebar
+    concept_focus: str  # the single concept this sub-lesson teaches
+    activity_seed: ActivitySeed
+    difficulty_level: int  # 1=intro, 2=application, 3=pre-mastery
+
+
+class ObjectivePlanOutput(BaseModel):
+    """Output from the lesson_planner agent.
+
+    Plans ALL sub-lessons (focused + capstone) for one objective at once.
+    """
+
+    objective_title: str  # used as group label in sidebar
+    key_concepts: list[str] = Field(min_length=2, max_length=4)
+    mastery_criteria: list[str] = Field(min_length=2, max_length=6)
+    sub_lesson_seeds: list[SubLessonSeed] = Field(min_length=2, max_length=3)
+    capstone_seed: ActivitySeed  # integrative, hardest
+
+
 class LessonContentOutput(BaseModel):
     """Output from the lesson_writer agent."""
 
     lesson_title: str
-    lesson_body: str = Field(min_length=200)
-    key_takeaways: list[str] = Field(min_length=3, max_length=6)
+    lesson_body: str = Field(min_length=100)  # short for focused; longer for capstone
+    key_takeaways: list[str] = Field(min_length=2, max_length=4)

--- a/backend/src/app/services/activity_review.py
+++ b/backend/src/app/services/activity_review.py
@@ -9,12 +9,12 @@ from app.agents.activity_reviewer import run_activity_reviewer
 from app.agents.logging import AgentContext
 from app.db.models import Activity, CourseInstance, Lesson
 from app.db.session import get_background_session
-from app.services.generation import generate_lesson_on_demand
+from app.services.generation import generate_objective_on_demand
 from app.services.generation_tracker import broadcast, is_running, start_generation
 from app.services.progression import (
     check_all_lessons_completed,
     transition_course,
-    unlock_next_lesson,
+    unlock_next_sub_lesson,
 )
 
 logger = logging.getLogger(__name__)
@@ -32,12 +32,18 @@ async def review_activity_background(
     activity_prompt: str,
     scoring_rubric: list[str],
     course_id: str,
+    is_capstone: bool = True,
 ) -> None:
-    """Background task that reviews an activity submission via LLM."""
+    """Background task that reviews an activity submission via LLM.
+
+    Args:
+        is_capstone: If True, mastery gate applies (≥70 required to advance).
+                     If False (focused sub-lesson), any attempt marks lesson complete.
+    """
     key = review_key(activity_id)
 
     # Capture generation data before entering the DB session
-    next_lesson_to_generate: tuple[int, list[str], str] | None = None
+    next_objective_to_generate: tuple[int, list[str], str, dict | None] | None = None
 
     try:
         async with get_background_session() as db:
@@ -74,21 +80,34 @@ async def review_activity_background(
             activity.mastery_decision = review.mastery_decision
             activity.attempt_count += 1
 
-            # Mark lesson as completed and unlock next (only if mastery met)
-            if lesson.status != "completed" and review.mastery_decision in ("meets", "exceeds"):
-                completed_index = lesson.objective_index
-                lesson.status = "completed"
-                next_lesson = await unlock_next_lesson(db, course.id, completed_index)
+            # Determine gate: focused = attempt-gated, capstone = mastery-gated
+            lesson_role = lesson.lesson_role or "capstone"  # null = legacy capstone
+            advance = False
 
-                # If the unlocked lesson has no content yet, schedule on-demand generation
-                if next_lesson and next_lesson.lesson_content is None:
-                    next_lesson_to_generate = (
+            if lesson_role == "focused":
+                # Any reviewed attempt marks the focused lesson as complete
+                if lesson.status != "completed":
+                    advance = True
+            else:
+                # Capstone: require meets or exceeds
+                if lesson.status != "completed" and review.mastery_decision in ("meets", "exceeds"):
+                    advance = True
+
+            if advance:
+                lesson.status = "completed"
+                next_lesson = await unlock_next_sub_lesson(db, course_id, lesson)
+
+                # For capstone completions only: check if the next objective needs generation
+                if lesson_role != "focused" and next_lesson and next_lesson.lesson_content is None:
+                    next_objective_to_generate = (
                         next_lesson.objective_index,
                         list(course.input_objectives),
                         course.generated_description or course.input_description or "",
+                        course.diagnostic_analysis,
                     )
 
-                if await check_all_lessons_completed(db, course.id):
+                # Check if ALL lessons across the whole course are now completed
+                if lesson_role != "focused" and await check_all_lessons_completed(db, course.id):
                     result = await db.execute(
                         select(CourseInstance)
                         .where(CourseInstance.id == course.id)
@@ -106,21 +125,22 @@ async def review_activity_background(
             await db.flush()
             await db.commit()
 
-        # Kick off on-demand generation after the session has committed
-        if next_lesson_to_generate:
-            next_index, objectives, description = next_lesson_to_generate
-            gen_key = f"lesson-gen-{course_id}-{next_index}"
+        # Kick off on-demand generation for next objective after the session has committed
+        if next_objective_to_generate:
+            next_index, objectives, description, diagnostic_analysis = next_objective_to_generate
+            gen_key = f"objective-gen-{course_id}-{next_index}"
             if not is_running(gen_key):
                 logger.info(
                     "Scheduling on-demand generation for course [%s] obj[%d]",
                     course_id[:8], next_index,
                 )
-                start_generation(gen_key, generate_lesson_on_demand(
+                start_generation(gen_key, generate_objective_on_demand(
                     course_id=course_id,
                     user_id=user_id,
                     objective_index=next_index,
                     objectives=objectives,
                     description=description,
+                    diagnostic_analysis=diagnostic_analysis,
                 ))
 
         # Broadcast review result AFTER commit

--- a/backend/src/app/services/generation.py
+++ b/backend/src/app/services/generation.py
@@ -4,6 +4,7 @@ import logging
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
+from app.agents.diagnostic import run_diagnostic_creator
 from app.agents.logging import AgentContext
 from app.agents.lesson_planner import run_lesson_planner
 from app.agents.lesson_writer import run_lesson_writer
@@ -16,6 +17,33 @@ from app.services.progression import transition_course
 logger = logging.getLogger(__name__)
 
 
+async def generate_diagnostic(course_id: str, user_id: str) -> dict:
+    """Generate diagnostic questions for a course synchronously.
+
+    Returns the diagnostic spec dict, or an empty dict on failure.
+    """
+    course_id_short = course_id[:8]
+    try:
+        async with get_background_session() as db:
+            result = await db.execute(
+                select(CourseInstance).where(CourseInstance.id == course_id)
+            )
+            course = result.scalar_one()
+            ctx = AgentContext(db=db, user_id=user_id, course_instance_id=course_id)
+            spec = await run_diagnostic_creator(
+                ctx,
+                objectives=list(course.input_objectives),
+                course_description=course.input_description or "",
+            )
+            course.diagnostic_spec = spec.model_dump()
+            await db.commit()
+            logger.info("[%s] diagnostic questions generated (%d questions)", course_id_short, len(spec.questions))
+            return spec.model_dump()
+    except Exception:
+        logger.exception("[%s] Failed to generate diagnostic", course_id_short)
+        return {}
+
+
 async def _generate_single_objective(
     course_id: str,
     user_id: str,
@@ -24,13 +52,10 @@ async def _generate_single_objective(
     description: str,
     all_objectives: list[str],
     learner_profile: dict | None,
+    diagnostic_analysis: dict | None,
     semaphore: asyncio.Semaphore,
 ) -> bool:
-    """Generate a single objective's lesson and activity.
-
-    Each coroutine owns its own DB session so concurrent objectives never
-    share an AsyncSession. LLM calls are gated by the semaphore to limit
-    parallel API usage.
+    """Generate all sub-lessons + capstone for one objective.
 
     Returns True on success, False on error.
     """
@@ -40,7 +65,7 @@ async def _generate_single_objective(
 
     try:
         async with get_background_session() as db:
-            # Check for existing lesson at this index (retry/skip support)
+            # Check for existing lessons at this objective (retry/skip support)
             result = await db.execute(
                 select(Lesson)
                 .where(
@@ -49,17 +74,21 @@ async def _generate_single_objective(
                 )
                 .options(selectinload(Lesson.activities))
             )
-            existing = result.scalar_one_or_none()
+            existing_lessons = result.scalars().all()
 
-            # Skip path: already fully generated
-            if existing and existing.lesson_content and existing.activities:
+            # Skip path: all sub-lessons + capstone already exist with content
+            capstone = next(
+                (l for l in existing_lessons if l.lesson_role == "capstone"),
+                None
+            )
+            if capstone and capstone.lesson_content and capstone.activities:
                 logger.info(
                     "[%s] %s SKIP (already generated): %s",
                     course_id_short, obj_label, obj_preview,
                 )
                 await broadcast(course_id, "lesson_planned", {
                     "objective_index": objective_index,
-                    "lesson_title": None,
+                    "objective_title": capstone.lesson_title or "",
                     "skipped": True,
                 })
                 await broadcast(course_id, "lesson_written", {
@@ -68,124 +97,203 @@ async def _generate_single_objective(
                 })
                 await broadcast(course_id, "activity_created", {
                     "objective_index": objective_index,
-                    "activity_id": existing.activities[0].id,
+                    "activity_id": capstone.activities[0].id,
                     "skipped": True,
                 })
                 return True
 
-            logger.info(
-                "[%s] %s START: %s",
-                course_id_short, obj_label, obj_preview,
-            )
+            logger.info("[%s] %s START: %s", course_id_short, obj_label, obj_preview)
 
-            ctx = AgentContext(
-                db=db,
-                user_id=user_id,
-                course_instance_id=course_id,
-            )
+            ctx = AgentContext(db=db, user_id=user_id, course_instance_id=course_id)
 
-            # 1. Plan the lesson
+            # 1. Plan all sub-lessons + capstone for this objective
             logger.info("[%s] %s waiting for semaphore (lesson_planner)…", course_id_short, obj_label)
             async with semaphore:
                 logger.info("[%s] %s running lesson_planner…", course_id_short, obj_label)
                 plan = await run_lesson_planner(
-                    ctx, objective, description, all_objectives, learner_profile,
+                    ctx, objective, description, all_objectives, learner_profile, diagnostic_analysis,
                 )
             logger.info(
-                "[%s] %s lesson_planner done → title: %r | concepts: %d | outline steps: %d",
-                course_id_short, obj_label, plan.lesson_title,
-                len(plan.key_concepts), len(plan.lesson_outline),
+                "[%s] %s lesson_planner done → title: %r | concepts: %d | sub-lessons: %d",
+                course_id_short, obj_label, plan.objective_title,
+                len(plan.key_concepts), len(plan.sub_lesson_seeds),
             )
-
-            # Create or reuse the lesson row
-            if not existing:
-                lesson = Lesson(
-                    course_instance_id=course_id,
-                    objective_index=objective_index,
-                    lesson_content=None,
-                    status="unlocked" if objective_index == 0 else "locked",
-                )
-                db.add(lesson)
-                await db.flush()
-                await db.commit()
-                logger.debug("[%s] %s lesson row created (id=%s)", course_id_short, obj_label, lesson.id[:8])
-            else:
-                lesson = existing
 
             await broadcast(course_id, "lesson_planned", {
                 "objective_index": objective_index,
-                "lesson_title": plan.lesson_title,
+                "objective_title": plan.objective_title,
+                "sub_lesson_count": len(plan.sub_lesson_seeds) + 1,  # +1 for capstone
             })
 
-            # 2. Write the lesson content
-            if lesson.lesson_content:
-                logger.info(
-                    "[%s] %s lesson_writer SKIP (content already exists)",
-                    course_id_short, obj_label,
-                )
-            else:
-                logger.info("[%s] %s waiting for semaphore (lesson_writer)…", course_id_short, obj_label)
-                async with semaphore:
-                    logger.info("[%s] %s running lesson_writer…", course_id_short, obj_label)
-                    content = await run_lesson_writer(
-                        ctx, plan, description, learner_profile,
+            # 2. Create all Lesson rows for this objective if they don't exist
+            existing_by_sub = {l.sub_lesson_index: l for l in existing_lessons}
+            lesson_rows: list[Lesson] = []
+
+            for seed in plan.sub_lesson_seeds:
+                if seed.sub_lesson_index not in existing_by_sub:
+                    is_first = (objective_index == 0 and seed.sub_lesson_index == 0)
+                    lesson = Lesson(
+                        course_instance_id=course_id,
+                        objective_index=objective_index,
+                        sub_lesson_index=seed.sub_lesson_index,
+                        lesson_role="focused",
+                        lesson_title=seed.title,
+                        lesson_content=None,
+                        status="unlocked" if is_first else "locked",
                     )
-                lesson.lesson_content = content.lesson_body
+                    db.add(lesson)
+                    lesson_rows.append(lesson)
+                else:
+                    lesson_rows.append(existing_by_sub[seed.sub_lesson_index])
+
+            # Capstone row
+            capstone_sub_idx = len(plan.sub_lesson_seeds)
+            if capstone_sub_idx not in existing_by_sub:
+                capstone_lesson = Lesson(
+                    course_instance_id=course_id,
+                    objective_index=objective_index,
+                    sub_lesson_index=capstone_sub_idx,
+                    lesson_role="capstone",
+                    lesson_title=f"{plan.objective_title} — Capstone",
+                    lesson_content=None,
+                    status="locked",
+                )
+                db.add(capstone_lesson)
+            else:
+                capstone_lesson = existing_by_sub[capstone_sub_idx]
+
+            await db.flush()
+            await db.commit()
+            logger.debug(
+                "[%s] %s lesson rows created/found: %d focused + 1 capstone",
+                course_id_short, obj_label, len(plan.sub_lesson_seeds),
+            )
+
+            # 3. Write and create activities for each focused sub-lesson
+            for i, seed in enumerate(plan.sub_lesson_seeds):
+                lesson = lesson_rows[i]
+                sl_label = f"{obj_label}/sub[{seed.sub_lesson_index}]"
+
+                if not lesson.lesson_content:
+                    logger.info("[%s] %s waiting for semaphore (lesson_writer)…", course_id_short, sl_label)
+                    async with semaphore:
+                        logger.info("[%s] %s running lesson_writer…", course_id_short, sl_label)
+                        content = await run_lesson_writer(
+                            ctx, seed, objective, description, learner_profile,
+                            lesson_role="focused",
+                        )
+                    lesson.lesson_content = content.lesson_body
+                    lesson.lesson_title = content.lesson_title
+                    await db.flush()
+                    await db.commit()
+                    logger.info(
+                        "[%s] %s lesson_writer done → %d chars",
+                        course_id_short, sl_label, len(content.lesson_body),
+                    )
+
+                await broadcast(course_id, "lesson_written", {
+                    "objective_index": objective_index,
+                    "sub_lesson_index": seed.sub_lesson_index,
+                })
+
+                if not lesson.activities:
+                    logger.info("[%s] %s waiting for semaphore (activity_creator)…", course_id_short, sl_label)
+                    async with semaphore:
+                        logger.info("[%s] %s running activity_creator (focused, level %d)…", course_id_short, sl_label, seed.difficulty_level)
+                        activity_spec = await run_activity_creator(
+                            ctx, seed.activity_seed, objective,
+                            plan.mastery_criteria, learner_profile,
+                            difficulty_level=seed.difficulty_level,
+                            lesson_role="focused",
+                            concept_focus=seed.concept_focus,
+                        )
+                    activity = Activity(
+                        lesson_id=lesson.id,
+                        activity_spec=activity_spec.model_dump(),
+                    )
+                    db.add(activity)
+                    await db.flush()
+                    await db.commit()
+                    logger.info(
+                        "[%s] %s activity_creator done → rubric: %d items",
+                        course_id_short, sl_label, len(activity_spec.scoring_rubric),
+                    )
+                else:
+                    activity = lesson.activities[0]
+
+                await broadcast(course_id, "activity_created", {
+                    "objective_index": objective_index,
+                    "sub_lesson_index": seed.sub_lesson_index,
+                    "activity_id": activity.id,
+                    "lesson_role": "focused",
+                })
+
+            # 4. Write and create activity for capstone
+            cap_label = f"{obj_label}/capstone"
+
+            if not capstone_lesson.lesson_content:
+                logger.info("[%s] %s waiting for semaphore (lesson_writer)…", course_id_short, cap_label)
+                async with semaphore:
+                    logger.info("[%s] %s running lesson_writer (capstone)…", course_id_short, cap_label)
+                    cap_content = await run_lesson_writer(
+                        ctx, None, objective, description, learner_profile,
+                        lesson_role="capstone",
+                        key_concepts=plan.key_concepts,
+                        mastery_criteria=plan.mastery_criteria,
+                    )
+                capstone_lesson.lesson_content = cap_content.lesson_body
+                capstone_lesson.lesson_title = cap_content.lesson_title
                 await db.flush()
                 await db.commit()
                 logger.info(
-                    "[%s] %s lesson_writer done → %d chars, %d takeaways",
-                    course_id_short, obj_label,
-                    len(content.lesson_body), len(content.key_takeaways),
+                    "[%s] %s lesson_writer done → %d chars",
+                    course_id_short, cap_label, len(cap_content.lesson_body),
                 )
 
             await broadcast(course_id, "lesson_written", {
                 "objective_index": objective_index,
+                "sub_lesson_index": capstone_sub_idx,
             })
 
-            # 3. Create the activity (only if lesson doesn't already have one)
-            if not existing or not existing.activities:
-                logger.info("[%s] %s waiting for semaphore (activity_creator)…", course_id_short, obj_label)
+            if not capstone_lesson.activities:
+                logger.info("[%s] %s waiting for semaphore (activity_creator)…", course_id_short, cap_label)
                 async with semaphore:
-                    logger.info("[%s] %s running activity_creator…", course_id_short, obj_label)
-                    activity_spec = await run_activity_creator(
-                        ctx, plan.suggested_activity, objective,
+                    logger.info("[%s] %s running activity_creator (capstone)…", course_id_short, cap_label)
+                    cap_spec = await run_activity_creator(
+                        ctx, plan.capstone_seed, objective,
                         plan.mastery_criteria, learner_profile,
+                        difficulty_level=3,
+                        lesson_role="capstone",
                     )
-                activity = Activity(
-                    lesson_id=lesson.id,
-                    activity_spec=activity_spec.model_dump(),
+                cap_activity = Activity(
+                    lesson_id=capstone_lesson.id,
+                    activity_spec=cap_spec.model_dump(),
                 )
-                db.add(activity)
+                db.add(cap_activity)
                 await db.flush()
                 await db.commit()
                 logger.info(
-                    "[%s] %s activity_creator done → rubric items: %d, hints: %d",
-                    course_id_short, obj_label,
-                    len(activity_spec.scoring_rubric), len(activity_spec.hints),
+                    "[%s] %s activity_creator done → rubric: %d items",
+                    course_id_short, cap_label, len(cap_spec.scoring_rubric),
                 )
             else:
-                activity = existing.activities[0]
-                logger.info(
-                    "[%s] %s activity_creator SKIP (activity already exists id=%s)",
-                    course_id_short, obj_label, activity.id[:8],
-                )
+                cap_activity = capstone_lesson.activities[0]
 
             await broadcast(course_id, "activity_created", {
                 "objective_index": objective_index,
-                "activity_id": activity.id,
+                "sub_lesson_index": capstone_sub_idx,
+                "activity_id": cap_activity.id,
+                "lesson_role": "capstone",
             })
 
             logger.info("[%s] %s COMPLETE ✓", course_id_short, obj_label)
             return True
 
     except Exception:
-        logger.exception(
-            "[%s] %s FAILED: %s", course_id_short, obj_label, obj_preview,
-        )
+        logger.exception("[%s] %s FAILED: %s", course_id_short, obj_label, obj_preview)
         await broadcast(course_id, "generation_error", {
             "objective_index": objective_index,
-            "error": f"Failed to generate lesson for objective {objective_index}",
+            "error": f"Failed to generate lessons for objective {objective_index}",
         })
         return False
 
@@ -196,16 +304,16 @@ async def generate_course_background(
     objectives: list[str],
     description: str,
     learner_profile: dict | None = None,
+    diagnostic_analysis: dict | None = None,
 ) -> None:
-    """Background task that generates only the first lesson (lesson 0).
+    """Background task that generates all sub-lessons for objective 0.
 
-    Subsequent lessons are generated on demand via generate_lesson_on_demand
-    as the learner progresses through the course.
+    Subsequent objectives are generated on demand as the learner progresses.
     """
     course_id_short = course_id[:8]
 
     logger.info(
-        "[%s] GENERATION START | generating lesson 0 of %d | model: %s",
+        "[%s] GENERATION START | generating objective 0 of %d | model: %s",
         course_id_short, len(objectives),
         __import__("app.config", fromlist=["settings"]).settings.default_model,
     )
@@ -216,13 +324,13 @@ async def generate_course_background(
     try:
         success = await _generate_single_objective(
             course_id, user_id, 0, objectives[0], description,
-            objectives, learner_profile, asyncio.Semaphore(1),
+            objectives, learner_profile, diagnostic_analysis, asyncio.Semaphore(1),
         )
         lessons_created = 1 if success else 0
 
         logger.info(
             "[%s] Initial generation %s",
-            course_id_short, "succeeded — lesson 0 ready" if success else "failed",
+            course_id_short, "succeeded — objective 0 ready" if success else "failed",
         )
 
         # Finalize course status
@@ -241,12 +349,11 @@ async def generate_course_background(
             else:
                 await transition_course(db, course, "generation_failed")
 
-        # Broadcast AFTER the session commits so SSE subscribers see committed data.
         await broadcast(course_id, "generation_complete", {
             "course_id": course_id,
             "lesson_count": lessons_created,
         })
-        logger.info("[%s] GENERATION COMPLETE | lesson 0 ready", course_id_short)
+        logger.info("[%s] GENERATION COMPLETE | objective 0 ready", course_id_short)
 
     except Exception:
         logger.exception("[%s] FATAL error in background generation", course_id_short)
@@ -271,17 +378,18 @@ async def generate_course_background(
         })
 
 
-async def generate_lesson_on_demand(
+async def generate_objective_on_demand(
     course_id: str,
     user_id: str,
     objective_index: int,
     objectives: list[str],
     description: str,
     learner_profile: dict | None = None,
+    diagnostic_analysis: dict | None = None,
 ) -> None:
-    """Generate a single lesson on demand when the learner unlocks it.
+    """Generate all sub-lessons for an objective on demand when the learner unlocks it.
 
-    The lesson row already exists (created by unlock_next_lesson) with no content.
+    Called when a learner completes the capstone of the previous objective.
     """
     course_id_short = course_id[:8]
     logger.info(
@@ -290,5 +398,5 @@ async def generate_lesson_on_demand(
     )
     await _generate_single_objective(
         course_id, user_id, objective_index, objectives[objective_index],
-        description, objectives, learner_profile, asyncio.Semaphore(1),
+        description, objectives, learner_profile, diagnostic_analysis, asyncio.Semaphore(1),
     )

--- a/backend/src/app/services/progression.py
+++ b/backend/src/app/services/progression.py
@@ -15,7 +15,8 @@ class InvalidTransitionError(Exception):
 
 # Valid transitions and their guard conditions
 TRANSITIONS: dict[tuple[str, str], str] = {
-    ("draft", "generating"): "has_objectives",
+    ("draft", "awaiting_diagnostic"): "has_objectives",
+    ("awaiting_diagnostic", "generating"): "always",
     ("generating", "active"): "all_content_generated",
     ("active", "in_progress"): "always",
     ("in_progress", "awaiting_assessment"): "all_lessons_completed",
@@ -26,7 +27,7 @@ TRANSITIONS: dict[tuple[str, str], str] = {
     ("assessment_ready", "generating_assessment"): "always",  # retry
     ("assessment_ready", "completed"): "assessment_passed",
     ("generating", "generation_failed"): "always",
-    ("generation_failed", "generating"): "always",
+    ("generation_failed", "awaiting_diagnostic"): "always",  # retry goes back to diagnostic
 }
 
 
@@ -73,55 +74,100 @@ async def transition_course(
     return course
 
 
-async def unlock_next_lesson(
-    db: AsyncSession, course_id: str, completed_index: int
+async def unlock_next_sub_lesson(
+    db: AsyncSession,
+    course_id: str,
+    completed_lesson: Lesson,
 ) -> Lesson | None:
-    """Unlock or create the next lesson after completed_index.
+    """Unlock the next sub-lesson based on the completed lesson's role.
 
-    With on-demand generation, lesson rows are created here rather than upfront.
-    Returns the unlocked/created lesson, or None if completed_index is the last objective.
+    - If lesson_role == "focused": unlock the next sub-lesson in the same objective
+      (sub_lesson_index + 1).
+    - If lesson_role == "capstone": unlock sub_lesson_index=0 of the next objective.
+
+    Returns the unlocked lesson, or None if there is no next lesson.
     """
-    next_index = completed_index + 1
+    lesson_role = completed_lesson.lesson_role or "capstone"  # null = legacy capstone
 
-    # Bounds check against total objectives
-    result = await db.execute(
-        select(CourseInstance).where(CourseInstance.id == course_id)
-    )
-    course = result.scalar_one()
-    if next_index >= len(course.input_objectives):
-        logger.info(
-            "course [%s] obj[%d] is the last lesson — no next lesson to unlock",
-            course_id[:8], completed_index,
+    if lesson_role == "focused":
+        # Unlock next sub-lesson within the same objective
+        next_sub_idx = completed_lesson.sub_lesson_index + 1
+        result = await db.execute(
+            select(Lesson).where(
+                Lesson.course_instance_id == course_id,
+                Lesson.objective_index == completed_lesson.objective_index,
+                Lesson.sub_lesson_index == next_sub_idx,
+            )
+        )
+        next_lesson = result.scalar_one_or_none()
+        if next_lesson:
+            if next_lesson.status == "locked":
+                next_lesson.status = "unlocked"
+                await db.flush()
+                logger.info(
+                    "course [%s] unlocked obj[%d]/sub[%d]",
+                    course_id[:8], completed_lesson.objective_index, next_sub_idx,
+                )
+            return next_lesson
+        # No next sub-lesson found (shouldn't happen for focused lessons)
+        logger.warning(
+            "course [%s] focused lesson completed but no next sub-lesson found at obj[%d]/sub[%d]",
+            course_id[:8], completed_lesson.objective_index, next_sub_idx,
         )
         return None
 
-    # Try to find an existing row for the next index
-    result = await db.execute(
-        select(Lesson).where(
-            Lesson.course_instance_id == course_id,
-            Lesson.objective_index == next_index,
-        )
-    )
-    lesson = result.scalar_one_or_none()
-
-    if lesson:
-        if lesson.status == "locked":
-            lesson.status = "unlocked"
-            await db.flush()
-            logger.info("course [%s] unlocked existing lesson obj[%d]", course_id[:8], next_index)
     else:
-        # Create the row on demand
-        lesson = Lesson(
-            course_instance_id=course_id,
-            objective_index=next_index,
-            lesson_content=None,
-            status="unlocked",
-        )
-        db.add(lesson)
-        await db.flush()
-        logger.info("course [%s] created on-demand lesson row obj[%d]", course_id[:8], next_index)
+        # Capstone completed — unlock first sub-lesson of next objective
+        next_obj_idx = completed_lesson.objective_index + 1
 
-    return lesson
+        # Bounds check
+        result = await db.execute(
+            select(CourseInstance).where(CourseInstance.id == course_id)
+        )
+        course = result.scalar_one()
+        if next_obj_idx >= len(course.input_objectives):
+            logger.info(
+                "course [%s] capstone obj[%d] is last objective — course complete",
+                course_id[:8], completed_lesson.objective_index,
+            )
+            return None
+
+        # Try to find existing first sub-lesson of next objective
+        result = await db.execute(
+            select(Lesson).where(
+                Lesson.course_instance_id == course_id,
+                Lesson.objective_index == next_obj_idx,
+                Lesson.sub_lesson_index == 0,
+            )
+        )
+        next_lesson = result.scalar_one_or_none()
+
+        if next_lesson:
+            if next_lesson.status == "locked":
+                next_lesson.status = "unlocked"
+                await db.flush()
+                logger.info(
+                    "course [%s] unlocked obj[%d]/sub[0] (next objective)",
+                    course_id[:8], next_obj_idx,
+                )
+        else:
+            # Lesson rows for next objective not yet created — create placeholder
+            next_lesson = Lesson(
+                course_instance_id=course_id,
+                objective_index=next_obj_idx,
+                sub_lesson_index=0,
+                lesson_role="focused",
+                lesson_content=None,
+                status="unlocked",
+            )
+            db.add(next_lesson)
+            await db.flush()
+            logger.info(
+                "course [%s] created placeholder lesson row for obj[%d]/sub[0]",
+                course_id[:8], next_obj_idx,
+            )
+
+        return next_lesson
 
 
 async def check_all_lessons_completed(db: AsyncSession, course_id: str) -> bool:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { LoginPage } from '@/pages/LoginPage';
 import { RegisterPage } from '@/pages/RegisterPage';
 import { SettingsPage } from '@/pages/SettingsPage';
 import { AgentLogsPage } from '@/pages/AgentLogsPage';
+import { DiagnosticPage } from '@/pages/DiagnosticPage';
 import { useAuthStore } from '@/stores/auth-store';
 import { Loader2 } from 'lucide-react';
 
@@ -52,6 +53,10 @@ export default function App() {
             <Route index element={<Navigate to="/catalog" replace />} />
             <Route path="catalog" element={<CatalogPage />} />
             <Route path="courses/new" element={<CreateCoursePage />} />
+            <Route
+              path="courses/:courseId/diagnostic"
+              element={<DiagnosticPage />}
+            />
             <Route
               path="courses/:courseId/generate"
               element={<GenerationPage />}

--- a/frontend/src/api/courses.ts
+++ b/frontend/src/api/courses.ts
@@ -13,7 +13,7 @@ export function createCourse(
 
 export function triggerGeneration(
   courseId: string,
-): Promise<{ id: string; status: string }> {
+): Promise<{ id: string; status: string; diagnostic_spec?: unknown }> {
   return post(`/api/courses/${courseId}/generate`);
 }
 

--- a/frontend/src/api/diagnostics.ts
+++ b/frontend/src/api/diagnostics.ts
@@ -1,0 +1,15 @@
+import { post, get } from './client';
+import type { DiagnosticSpec } from './types';
+
+export function getDiagnostic(
+  courseId: string,
+): Promise<{ status: string; diagnostic_spec: DiagnosticSpec | null }> {
+  return get(`/api/courses/${courseId}/diagnostic`);
+}
+
+export function submitDiagnostic(
+  courseId: string,
+  responses: { question: string; answer: string }[],
+): Promise<{ id: string; status: string }> {
+  return post(`/api/courses/${courseId}/diagnostic/submit`, { responses });
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -23,6 +23,16 @@ export interface CourseListItem {
   lessons_completed: number;
 }
 
+// ---- Diagnostic ----
+export interface DiagnosticQuestion {
+  question: string;
+  rationale: string;
+}
+
+export interface DiagnosticSpec {
+  questions: DiagnosticQuestion[];
+}
+
 export interface CourseResponse {
   id: string;
   source_type: 'custom' | 'predefined';
@@ -30,12 +40,14 @@ export interface CourseResponse {
   input_objectives: string[];
   generated_description: string | null;
   status: CourseStatus;
+  diagnostic_spec: DiagnosticSpec | null;
   lessons: LessonResponse[];
   assessments: AssessmentSummary[];
 }
 
 export type CourseStatus =
   | 'draft'
+  | 'awaiting_diagnostic'
   | 'generating'
   | 'active'
   | 'in_progress'
@@ -49,6 +61,9 @@ export type CourseStatus =
 export interface LessonResponse {
   id: string;
   objective_index: number;
+  sub_lesson_index: number;
+  lesson_role: 'focused' | 'capstone';
+  lesson_title: string | null;
   lesson_content: string | null;
   status: 'locked' | 'unlocked' | 'completed';
   activity: ActivitySummary | null;
@@ -150,18 +165,22 @@ export interface AgentLog {
 // ---- SSE Events ----
 export interface LessonPlannedEvent {
   objective_index: number;
-  lesson_title: string;
+  objective_title?: string;
+  sub_lesson_count?: number;
   skipped?: boolean;
 }
 
 export interface LessonWrittenEvent {
   objective_index: number;
+  sub_lesson_index?: number;
   skipped?: boolean;
 }
 
 export interface ActivityCreatedEvent {
   objective_index: number;
+  sub_lesson_index?: number;
   activity_id: string;
+  lesson_role?: 'focused' | 'capstone';
   skipped?: boolean;
 }
 

--- a/frontend/src/components/course/LessonSidebar.tsx
+++ b/frontend/src/components/course/LessonSidebar.tsx
@@ -13,34 +13,60 @@ export function LessonSidebar({ course }: LessonSidebarProps) {
   const completed = course.lessons.filter((l) => l.status === 'completed').length;
   const allCompleted = completed === course.lessons.length && course.lessons.length > 0;
 
+  // Group lessons by objective_index, preserving flat array index for routes
+  const byObjective = course.lessons.reduce<
+    Map<number, { lesson: CourseResponse['lessons'][number]; flatIndex: number }[]>
+  >((acc, lesson, i) => {
+    const key = lesson.objective_index;
+    if (!acc.has(key)) acc.set(key, []);
+    acc.get(key)!.push({ lesson, flatIndex: i });
+    return acc;
+  }, new Map());
+
+  const objectives = Array.from(byObjective.entries()).sort(([a], [b]) => a - b);
+
   return (
     <aside className="w-64 shrink-0 space-y-4">
       <ProgressBar completed={completed} total={course.lessons.length} />
 
-      <nav className="space-y-1">
-        {course.lessons.map((lesson, i) => (
-          <NavLink
-            key={lesson.id}
-            to={`/courses/${course.id}/lessons/${i}`}
-            className={({ isActive }) =>
-              cn(
-                'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
-                isActive
-                  ? 'bg-accent font-medium text-accent-foreground'
-                  : 'hover:bg-muted',
-                lesson.status === 'locked' && 'pointer-events-none opacity-50',
-              )
-            }
-          >
-            <span className="text-xs">
-              {lesson.status === 'completed'
-                ? '✓'
-                : lesson.status === 'locked'
-                  ? '🔒'
-                  : '○'}
-            </span>
-            <span className="truncate">Lesson {i + 1}</span>
-          </NavLink>
+      <nav className="space-y-3">
+        {objectives.map(([objIdx, entries]) => (
+          <div key={objIdx} className="space-y-1">
+            <p className="px-3 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Objective {objIdx + 1}
+            </p>
+            {entries.map(({ lesson, flatIndex }) => (
+              <NavLink
+                key={lesson.id}
+                to={`/courses/${course.id}/lessons/${flatIndex}`}
+                className={({ isActive }) =>
+                  cn(
+                    'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
+                    isActive
+                      ? 'bg-accent font-medium text-accent-foreground'
+                      : 'hover:bg-muted',
+                    lesson.status === 'locked' && 'pointer-events-none opacity-50',
+                  )
+                }
+              >
+                <span className="text-xs shrink-0">
+                  {lesson.status === 'completed'
+                    ? '✓'
+                    : lesson.status === 'locked'
+                      ? '🔒'
+                      : lesson.lesson_role === 'capstone'
+                        ? '◇'
+                        : '○'}
+                </span>
+                <span className="truncate">
+                  {lesson.lesson_title ??
+                    (lesson.lesson_role === 'capstone'
+                      ? 'Capstone'
+                      : `Lesson ${flatIndex + 1}`)}
+                </span>
+              </NavLink>
+            ))}
+          </div>
         ))}
       </nav>
 

--- a/frontend/src/components/lesson/LessonNav.tsx
+++ b/frontend/src/components/lesson/LessonNav.tsx
@@ -11,9 +11,15 @@ export function LessonNav({ course, currentIndex }: LessonNavProps) {
   const navigate = useNavigate();
   const lesson = course.lessons[currentIndex];
   const hasActivity = lesson?.activity?.activity_spec != null;
+
+  // Focused lessons are attempt-gated: any mastery_decision (including not_yet) = done.
+  // Capstone/legacy lessons are mastery-gated: requires meets or exceeds.
   const activityDone =
-    lesson?.activity?.mastery_decision === 'meets' ||
-    lesson?.activity?.mastery_decision === 'exceeds';
+    lesson?.lesson_role === 'focused'
+      ? lesson?.activity?.mastery_decision != null
+      : lesson?.activity?.mastery_decision === 'meets' ||
+        lesson?.activity?.mastery_decision === 'exceeds';
+
   const isLast = currentIndex === course.lessons.length - 1;
 
   function goNext() {

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -4,6 +4,7 @@ export const AUTH_TOKEN_KEY = 'auth_token';
 
 export const STATUS_LABELS: Record<CourseStatus, string> = {
   draft: 'Draft',
+  awaiting_diagnostic: 'Awaiting Diagnostic',
   generating: 'Generating',
   active: 'Ready',
   in_progress: 'In Progress',
@@ -16,6 +17,7 @@ export const STATUS_LABELS: Record<CourseStatus, string> = {
 
 export const STATUS_COLORS: Record<CourseStatus, string> = {
   draft: 'bg-gray-100 text-gray-700',
+  awaiting_diagnostic: 'bg-yellow-100 text-yellow-700',
   generating: 'bg-yellow-100 text-yellow-700',
   active: 'bg-blue-100 text-blue-700',
   in_progress: 'bg-blue-100 text-blue-700',

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -21,6 +21,7 @@ export function ActivityPage() {
 
   const lesson = course?.lessons[lessonIndex];
   const activity = lesson?.activity;
+  const isFocused = lesson?.lesson_role === 'focused';
 
   // On mount, check if a review is in-flight via the REST endpoint
   useEffect(() => {
@@ -45,7 +46,7 @@ export function ActivityPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activity?.id]);
 
-  if (!course) return null;
+  if (!course || !lesson) return null;
 
   if (!activity?.activity_spec) {
     return <p className="text-muted-foreground">No activity for this lesson.</p>;
@@ -66,13 +67,18 @@ export function ActivityPage() {
         } as ActivityReviewResult
       : null);
 
-  const passed =
-    feedback?.mastery_decision === 'meets' ||
-    feedback?.mastery_decision === 'exceeds' ||
-    activity.mastery_decision === 'meets' ||
-    activity.mastery_decision === 'exceeds';
+  // Focused: attempt-gated — any feedback = can continue.
+  // Capstone/legacy: mastery-gated — requires meets or exceeds.
+  const masteryDecision = feedback?.mastery_decision ?? activity.mastery_decision;
+  const passed = isFocused
+    ? masteryDecision != null
+    : masteryDecision === 'meets' || masteryDecision === 'exceeds';
 
   const isLast = lessonIndex === course.lessons.length - 1;
+
+  const activityTitle = isFocused
+    ? `Practice Activity${lesson.lesson_title ? ` — ${lesson.lesson_title}` : ''}`
+    : `Capstone Activity${lesson.lesson_title ? ` — ${lesson.lesson_title}` : ''}`;
 
   function connectSSE(activityId: string) {
     cleanupRef.current?.();
@@ -119,9 +125,7 @@ export function ActivityPage() {
 
   return (
     <div className="space-y-6">
-      <h2 className="text-lg font-semibold">
-        Lesson {lessonIndex + 1} Activity
-      </h2>
+      <h2 className="text-lg font-semibold">{activityTitle}</h2>
 
       <ActivityPanel spec={activity.activity_spec} />
 

--- a/frontend/src/pages/CreateCoursePage.tsx
+++ b/frontend/src/pages/CreateCoursePage.tsx
@@ -46,8 +46,12 @@ export function CreateCoursePage() {
         description: description.trim(),
         objectives: trimmed,
       });
-      await triggerGeneration(id);
-      navigate(`/courses/${id}/generate`);
+      const result = await triggerGeneration(id);
+      if (result.status === 'awaiting_diagnostic') {
+        navigate(`/courses/${id}/diagnostic`);
+      } else {
+        navigate(`/courses/${id}/generate`);
+      }
     } catch (e) {
       setError((e as Error).message);
       setSubmitting(false);

--- a/frontend/src/pages/DiagnosticPage.tsx
+++ b/frontend/src/pages/DiagnosticPage.tsx
@@ -1,0 +1,102 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { getDiagnostic, submitDiagnostic } from '@/api/diagnostics';
+import type { DiagnosticSpec } from '@/api/types';
+
+export function DiagnosticPage() {
+  const { courseId } = useParams<{ courseId: string }>();
+  const navigate = useNavigate();
+  const [spec, setSpec] = useState<DiagnosticSpec | null>(null);
+  const [answers, setAnswers] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!courseId) return;
+    getDiagnostic(courseId)
+      .then(({ diagnostic_spec }) => {
+        if (diagnostic_spec) {
+          setSpec(diagnostic_spec);
+          setAnswers(new Array(diagnostic_spec.questions.length).fill(''));
+        }
+        setLoading(false);
+      })
+      .catch(() => {
+        setError('Failed to load diagnostic questions.');
+        setLoading(false);
+      });
+  }, [courseId]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!courseId || !spec) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const responses = spec.questions.map((q, i) => ({
+        question: q.question,
+        answer: answers[i],
+      }));
+      await submitDiagnostic(courseId, responses);
+      navigate(`/courses/${courseId}/generate`);
+    } catch (err) {
+      setError((err as Error).message);
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-6">
+        <h1 className="text-2xl font-bold">Preparing Your Course</h1>
+        <p className="text-muted-foreground">Loading diagnostic questions...</p>
+      </div>
+    );
+  }
+
+  const allAnswered = answers.every((a) => a.trim().length > 0);
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Before We Begin</h1>
+        <p className="text-muted-foreground">
+          Answer a few questions so we can tailor this course to your background and experience level.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {spec?.questions.map((q, i) => (
+          <div key={i} className="space-y-2">
+            <label className="text-sm font-medium">
+              {i + 1}. {q.question}
+            </label>
+            <Textarea
+              value={answers[i]}
+              onChange={(e) => {
+                const next = [...answers];
+                next[i] = e.target.value;
+                setAnswers(next);
+              }}
+              rows={3}
+              placeholder="Your answer..."
+            />
+          </div>
+        ))}
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <Button
+          type="submit"
+          disabled={submitting || !allAnswered}
+          className="w-full"
+        >
+          {submitting ? 'Analyzing your responses...' : 'Begin Course'}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/GenerationPage.tsx
+++ b/frontend/src/pages/GenerationPage.tsx
@@ -27,10 +27,21 @@ export function GenerationPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [courseId]);
 
+  // If the course still needs a diagnostic, redirect there instead of showing this page.
+  useEffect(() => {
+    if (!loading && courseStatus === 'awaiting_diagnostic' && courseId) {
+      navigate(`/courses/${courseId}/diagnostic`, { replace: true });
+    }
+  }, [loading, courseStatus, courseId, navigate]);
+
   // Determine if the generation finished but produced nothing (zombie state).
   // This happens when the backend process crashed or the server restarted
   // while the course was in "generating" status.
-  const isZombie = complete && progress.size === 0 && objectives.length > 0;
+  const isZombie =
+    complete &&
+    progress.size === 0 &&
+    objectives.length > 0 &&
+    courseStatus !== 'awaiting_diagnostic';
 
   // Has at least some lessons been successfully generated?
   const hasLessons = progress.size > 0;
@@ -39,7 +50,7 @@ export function GenerationPage() {
   // (status is past "generating", e.g. active, in_progress, completed)
   const alreadyGenerated =
     courseStatus != null &&
-    !['draft', 'generating', 'generation_failed'].includes(courseStatus);
+    !['draft', 'awaiting_diagnostic', 'generating', 'generation_failed'].includes(courseStatus);
 
   const [retrying, setRetrying] = useState(false);
 
@@ -52,7 +63,11 @@ export function GenerationPage() {
       if (courseStatus === 'generating') {
         await transitionCourse(courseId, 'generation_failed');
       }
-      await triggerGeneration(courseId);
+      const result = await triggerGeneration(courseId);
+      if (result.status === 'awaiting_diagnostic') {
+        navigate(`/courses/${courseId}/diagnostic`);
+        return;
+      }
       await init(courseId);
     } catch {
       // If transitions fail, just refresh to show current state

--- a/frontend/src/stores/generation-store.ts
+++ b/frontend/src/stores/generation-store.ts
@@ -124,7 +124,7 @@ export const useGenerationStore = create<GenerationState>((set, get) => ({
           case 'lesson_planned': {
             const e = existing(event.data.objective_index);
             progress.set(event.data.objective_index, {
-              ...e, planned: true, planTitle: event.data.lesson_title,
+              ...e, planned: true, planTitle: event.data.objective_title ?? null,
             });
             return { ...state, progress };
           }


### PR DESCRIPTION
## Summary

- **Pre-course diagnostic**: Before any content is generated, the learner answers 3–5 AI-generated questions. An analyzer agent produces rigor guidance (baseline level, concept gaps, strengths) that calibrates lesson depth and activity difficulty throughout the course.
- **Sub-lesson architecture**: Each objective now generates 2–3 focused sub-lessons + 1 capstone lesson (3–4 per objective, up from 1). Each sub-lesson covers a single concept with escalating difficulty (`difficulty_level` 1→3).
- **Role-based gating**: Focused sub-lessons are attempt-gated (any submission unlocks the next). Capstone lessons remain mastery-gated (≥70/meets required).
- **New course state**: `awaiting_diagnostic` sits between `draft` and `generating`. `POST /generate` now synchronously creates the diagnostic and returns it; `POST /diagnostic/submit` analyzes responses and kicks off background generation.

## Changes

### Backend
- **DB migration** (`3d50862c3ed3`): adds `sub_lesson_index`, `lesson_role`, `lesson_title` to `lessons`; adds `diagnostic_spec`, `diagnostic_responses`, `diagnostic_analysis` to `course_instances`
- **New agents**: `diagnostic_creator` and `diagnostic_analyzer` (both `fast_model`)
- **Updated agents**: `lesson_planner` now outputs `ObjectivePlanOutput` (all sub-lessons planned at once); `lesson_writer` handles focused vs capstone modes; `activity_creator` accepts `difficulty_level` and `lesson_role`
- **Generation service**: `generate_diagnostic()` runs synchronously; `_generate_single_objective` creates all sub-lessons + capstone in sequence; on-demand generation triggers per objective
- **Progression service**: new `unlock_next_sub_lesson()` replaces `unlock_next_lesson()`, handling both focused→next-sub-lesson and capstone→next-objective transitions
- **Activity review**: bifurcated gate logic — focused lessons complete on any attempt, capstones require meets/exceeds
- **New API endpoints**: `GET /courses/:id/diagnostic`, `POST /courses/:id/diagnostic/submit`

### Frontend
- **DiagnosticPage**: new page with per-question textareas; submits responses, then redirects to generation stream
- **LessonSidebar**: lessons grouped by objective with header labels; shows `lesson_title` when available; capstone marked with `◇`
- **LessonNav**: role-aware `activityDone` — focused uses attempt gate, capstone uses mastery gate
- **ActivityPage**: role-aware heading ("Practice Activity" vs "Capstone Activity"); focused lessons show Continue after any submission
- **GenerationPage**: redirects to `/diagnostic` if course is `awaiting_diagnostic`; zombie detection excludes that state
- **constants.ts**: `awaiting_diagnostic` added to `STATUS_LABELS` and `STATUS_COLORS`

## Migration

```bash
cd backend && PYTHONPATH=src uv run alembic upgrade head
```

Existing courses are unaffected — all new columns have server defaults (`sub_lesson_index=0`, `lesson_role='capstone'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)