### PR TITLE
Poc 5 lesson generation test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests
+        run: PYTHONPATH=src ANTHROPIC_API_KEY=test-key uv run pytest tests/ -v

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,61 @@
+name: Deploy to AWS
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests
+        run: PYTHONPATH=src ANTHROPIC_API_KEY=test-key uv run pytest tests/ -v
+
+  deploy:
+    name: Build and deploy
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image
+        env:
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build --platform linux/amd64 \
+            -t $ECR_REGISTRY:$IMAGE_TAG \
+            -t $ECR_REGISTRY:latest \
+            .
+          docker push $ECR_REGISTRY:$IMAGE_TAG
+          docker push $ECR_REGISTRY:latest
+
+      - name: Deploy to App Runner
+        run: |
+          aws apprunner start-deployment \
+            --service-arn ${{ secrets.APPRUNNER_SERVICE_ARN }}
+          echo "Deployment triggered. Monitor at https://console.aws.amazon.com/apprunner"

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ CLAUDE.local.md
 *.tfvars
 .terraform/
 *.tfstate
+*.tfstate.*
 *.tfstate.backup
 .terraform.lock.hcl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,18 @@ Examples: `fix-activity-scoring`, `add-learner-profile-integration`, `ui-lesson-
 
 Keep commits focused. Each commit should represent one logical change. Write clear commit messages that describe *why*, not just *what*.
 
-### 4. Keep your branch current
+### 4. Run the tests
+
+Before pushing, run the backend test suite:
+
+```bash
+cd backend
+PYTHONPATH=src ANTHROPIC_API_KEY=test-key uv run pytest tests/ -v
+```
+
+All tests must pass. If you changed generation-related code, update the corresponding test file — each file has a comment at the top describing what to update.
+
+### 5. Keep your branch current
 
 If `main` moves forward while you're working, rebase your branch on top of it:
 
@@ -38,7 +49,7 @@ git rebase origin/main
 
 Do this regularly — the longer you wait, the harder conflicts become.
 
-### 5. Open a pull request
+### 6. Open a pull request
 
 Push your branch and open a PR against `main`:
 
@@ -52,7 +63,7 @@ In your PR description, include:
 - Any notable decisions or trade-offs
 - Steps to test it manually (if applicable)
 
-### 6. Review and merge
+### 7. Review and merge
 
 PRs require at least one review before merging. Address feedback, push updates to the same branch, and merge once approved.
 
@@ -72,6 +83,15 @@ PRs require at least one review before merging. Address feedback, push updates t
 - **Do not force-push to `main`**
 - **Do not merge your own PR without a review** (unless working solo and explicitly agreed)
 - **Do not open a PR with unresolved merge conflicts** — rebase first
+- **Do not open a PR with failing tests** — the CI check will block the merge anyway
+
+## CI/CD
+
+Every PR to `main` automatically runs the test suite (`CI / Run tests`). This is a **required status check** — PRs cannot be merged until it passes.
+
+Every merge to `main` triggers an automatic deployment to AWS: tests run again, the Docker image is built and pushed to ECR, and App Runner deploys it.
+
+You don't need to run `infra/deploy.sh` manually — just merge a reviewed, passing PR.
 
 ## Local Dev Setup
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ product-vision.md  Product vision and screen specs
 api-contracts.md   Full API request/response contracts
 ```
 
+## Testing
+
+The backend has a suite of tests covering the generation pipeline, state machine, SSE tracker, and agent schemas. No real API key or database required — all external calls are mocked.
+
+```bash
+cd backend
+uv sync --extra dev          # install dev dependencies (one-time)
+PYTHONPATH=src ANTHROPIC_API_KEY=test-key uv run pytest tests/ -v
+```
+
+Tests live in `backend/tests/`. Each file has a comment at the top explaining what to update when the corresponding source code changes.
+
 ## Deploying to AWS
 
 The `infra/` directory contains Terraform to deploy the app on AWS App Runner with an RDS PostgreSQL database.
@@ -140,7 +152,9 @@ The `infra/` directory contains Terraform to deploy the app on AWS App Runner wi
 
 ### Redeploying
 
-After code changes, run `./infra/deploy.sh` from the repo root. It builds a new image, pushes to ECR, and triggers an App Runner deployment.
+**Automated (recommended):** Merge to `main` — GitHub Actions runs tests, builds the Docker image, pushes to ECR, and triggers App Runner automatically.
+
+**Manual:** Run `./infra/deploy.sh` from the repo root. Builds a new image, pushes to ECR, and triggers an App Runner deployment.
 
 ### Tearing down
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,129 @@
+"""Shared fixtures for the generation test suite."""
+
+import uuid as _uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _auto_id_add(obj):
+    """Assign a UUID to obj.id if it's None, mimicking SQLAlchemy's flush behavior."""
+    if hasattr(obj, "id") and obj.id is None:
+        obj.id = str(_uuid.uuid4())
+
+
+@pytest.fixture
+def mock_db():
+    """Minimal AsyncSession mock.
+
+    db.add() auto-assigns UUIDs to simulate what SQLAlchemy does during flush.
+    Tests can override add.side_effect but should include _auto_id_add when
+    they also need to collect the added objects.
+    """
+    session = AsyncMock()
+    session.add = MagicMock(side_effect=_auto_id_add)
+    return session
+
+
+@pytest.fixture
+def patch_background_session(mock_db):
+    """Patch get_background_session in generation.py to yield mock_db."""
+
+    @asynccontextmanager
+    async def _fake():
+        yield mock_db
+
+    with patch("app.services.generation.get_background_session", _fake):
+        yield mock_db
+
+
+@pytest.fixture
+def patch_broadcast():
+    """Suppress SSE broadcast calls in generation.py."""
+    with patch("app.services.generation.broadcast", new=AsyncMock()) as m:
+        yield m
+
+
+@pytest.fixture
+def sample_plan():
+    from app.schemas.lesson import ActivitySeed, LessonPlanOutput
+
+    return LessonPlanOutput(
+        lesson_title="Introduction to Variables",
+        learning_objective="Declare and use variables in Python",
+        key_concepts=["variable", "assignment", "type"],
+        mastery_criteria=[
+            "Can declare int/str/float variables",
+            "Can explain reassignment",
+        ],
+        suggested_activity=ActivitySeed(
+            activity_type="short-answer",
+            prompt="Explain what happens when you reassign a variable.",
+            expected_evidence=["mentions memory", "uses an example"],
+        ),
+        lesson_outline=[
+            "Define variable",
+            "Show assignment",
+            "Demonstrate types",
+            "Work through example",
+        ],
+    )
+
+
+@pytest.fixture
+def sample_content():
+    from app.schemas.lesson import LessonContentOutput
+
+    return LessonContentOutput(
+        lesson_title="Introduction to Variables",
+        lesson_body="A" * 200,
+        key_takeaways=[
+            "Variables store values",
+            "Types matter",
+            "Reassignment replaces the value",
+        ],
+    )
+
+
+@pytest.fixture
+def sample_activity_spec():
+    from app.schemas.activity import ActivitySpecOutput
+
+    return ActivitySpecOutput(
+        activity_type="short-answer",
+        instructions="B" * 50,
+        prompt="C" * 20,
+        scoring_rubric=["criterion 1", "criterion 2", "criterion 3"],
+        hints=["hint 1", "hint 2"],
+    )
+
+
+@pytest.fixture
+def sample_course():
+    from app.db.models import CourseInstance
+
+    c = CourseInstance()
+    c.id = "aaaaaaaa-0000-0000-0000-000000000000"
+    c.user_id = "user-0000"
+    c.status = "draft"
+    c.input_objectives = ["Understand variables", "Understand loops"]
+    c.input_description = "Intro to Python"
+    c.generated_description = None
+    c.lessons = []
+    c.assessments = []
+    return c
+
+
+@pytest.fixture
+def sample_lesson():
+    from app.db.models import Lesson
+
+    l = Lesson()
+    l.id = "bbbbbbbb-0000-0000-0000-000000000000"
+    l.course_instance_id = "aaaaaaaa-0000-0000-0000-000000000000"
+    l.objective_index = 0
+    l.lesson_content = None
+    l.status = "unlocked"
+    l.activities = []
+    return l

--- a/backend/tests/test_agents_contract.py
+++ b/backend/tests/test_agents_contract.py
@@ -1,0 +1,243 @@
+"""Schema contract tests for agent inputs/outputs.
+
+No DB, no LLM, no async needed. These tests verify that:
+1. The conftest fixtures produce schema-valid data
+2. Pydantic enforces the min/max constraints documented in each schema
+3. AgentContext holds the expected fields
+
+When schema fields change (schemas/lesson.py, schemas/activity.py):
+→ Update the conftest.py fixtures to match the new schema
+→ Update the constraint tests below if limits change
+These tests will fail at fixture construction if schemas break — intentional.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.agents.logging import AgentContext
+from app.schemas.activity import ActivityReviewOutput, ActivitySpecOutput
+from app.schemas.lesson import ActivitySeed, LessonContentOutput, LessonPlanOutput
+
+
+# ---------------------------------------------------------------------------
+# Fixtures round-trip through Pydantic
+# ---------------------------------------------------------------------------
+
+
+def test_lesson_plan_output_validates(sample_plan):
+    """conftest sample_plan is schema-valid and round-trips correctly."""
+    dumped = sample_plan.model_dump()
+    reparsed = LessonPlanOutput(**dumped)
+    assert reparsed.lesson_title == sample_plan.lesson_title
+    assert reparsed.learning_objective == sample_plan.learning_objective
+
+
+def test_lesson_content_output_validates(sample_content):
+    """conftest sample_content is schema-valid with lesson_body >= 200 chars."""
+    dumped = sample_content.model_dump()
+    reparsed = LessonContentOutput(**dumped)
+    assert len(reparsed.lesson_body) >= 200
+    assert len(reparsed.key_takeaways) >= 3
+
+
+def test_activity_spec_output_validates(sample_activity_spec):
+    """conftest sample_activity_spec is schema-valid with correct min lengths."""
+    dumped = sample_activity_spec.model_dump()
+    reparsed = ActivitySpecOutput(**dumped)
+    assert len(reparsed.instructions) >= 50
+    assert len(reparsed.prompt) >= 20
+    assert len(reparsed.scoring_rubric) >= 3
+    assert len(reparsed.hints) >= 2
+
+
+# ---------------------------------------------------------------------------
+# LessonPlanOutput constraints
+# ---------------------------------------------------------------------------
+
+
+def test_lesson_plan_rejects_too_few_key_concepts():
+    """key_concepts requires min 2 items."""
+    with pytest.raises(ValidationError):
+        LessonPlanOutput(
+            lesson_title="T",
+            learning_objective="O",
+            key_concepts=["only one"],  # min_length=2
+            mastery_criteria=["a", "b"],
+            suggested_activity=ActivitySeed(
+                activity_type="t",
+                prompt="p",
+                expected_evidence=["e1", "e2"],
+            ),
+            lesson_outline=["s1", "s2", "s3"],
+        )
+
+
+def test_lesson_plan_rejects_too_many_key_concepts():
+    """key_concepts is capped at 8 items."""
+    with pytest.raises(ValidationError):
+        LessonPlanOutput(
+            lesson_title="T",
+            learning_objective="O",
+            key_concepts=["c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9"],  # max=8
+            mastery_criteria=["a", "b"],
+            suggested_activity=ActivitySeed(
+                activity_type="t", prompt="p", expected_evidence=["e1", "e2"]
+            ),
+            lesson_outline=["s1", "s2", "s3"],
+        )
+
+
+def test_lesson_plan_rejects_too_few_mastery_criteria():
+    """mastery_criteria requires min 2 items."""
+    with pytest.raises(ValidationError):
+        LessonPlanOutput(
+            lesson_title="T",
+            learning_objective="O",
+            key_concepts=["c1", "c2"],
+            mastery_criteria=["only one"],  # min_length=2
+            suggested_activity=ActivitySeed(
+                activity_type="t", prompt="p", expected_evidence=["e1", "e2"]
+            ),
+            lesson_outline=["s1", "s2", "s3"],
+        )
+
+
+def test_lesson_plan_rejects_too_few_outline_steps():
+    """lesson_outline requires min 3 steps."""
+    with pytest.raises(ValidationError):
+        LessonPlanOutput(
+            lesson_title="T",
+            learning_objective="O",
+            key_concepts=["c1", "c2"],
+            mastery_criteria=["a", "b"],
+            suggested_activity=ActivitySeed(
+                activity_type="t", prompt="p", expected_evidence=["e1", "e2"]
+            ),
+            lesson_outline=["s1", "s2"],  # min_length=3
+        )
+
+
+# ---------------------------------------------------------------------------
+# LessonContentOutput constraints
+# ---------------------------------------------------------------------------
+
+
+def test_lesson_content_rejects_short_body():
+    """lesson_body must be at least 200 characters."""
+    with pytest.raises(ValidationError):
+        LessonContentOutput(
+            lesson_title="T",
+            lesson_body="too short",  # min_length=200
+            key_takeaways=["t1", "t2", "t3"],
+        )
+
+
+def test_lesson_content_rejects_too_few_takeaways():
+    """key_takeaways requires min 3 items."""
+    with pytest.raises(ValidationError):
+        LessonContentOutput(
+            lesson_title="T",
+            lesson_body="A" * 200,
+            key_takeaways=["t1", "t2"],  # min_length=3
+        )
+
+
+# ---------------------------------------------------------------------------
+# ActivitySpecOutput constraints
+# ---------------------------------------------------------------------------
+
+
+def test_activity_spec_rejects_short_instructions():
+    """instructions must be at least 50 characters."""
+    with pytest.raises(ValidationError):
+        ActivitySpecOutput(
+            activity_type="short-answer",
+            instructions="too short",  # min_length=50
+            prompt="C" * 20,
+            scoring_rubric=["r1", "r2", "r3"],
+            hints=["h1", "h2"],
+        )
+
+
+def test_activity_spec_rejects_short_prompt():
+    """prompt must be at least 20 characters."""
+    with pytest.raises(ValidationError):
+        ActivitySpecOutput(
+            activity_type="short-answer",
+            instructions="B" * 50,
+            prompt="short",  # min_length=20
+            scoring_rubric=["r1", "r2", "r3"],
+            hints=["h1", "h2"],
+        )
+
+
+def test_activity_spec_rejects_too_few_rubric_items():
+    """scoring_rubric requires min 3 items."""
+    with pytest.raises(ValidationError):
+        ActivitySpecOutput(
+            activity_type="short-answer",
+            instructions="B" * 50,
+            prompt="C" * 20,
+            scoring_rubric=["r1", "r2"],  # min_length=3
+            hints=["h1", "h2"],
+        )
+
+
+def test_activity_spec_rejects_too_few_hints():
+    """hints requires min 2 items."""
+    with pytest.raises(ValidationError):
+        ActivitySpecOutput(
+            activity_type="short-answer",
+            instructions="B" * 50,
+            prompt="C" * 20,
+            scoring_rubric=["r1", "r2", "r3"],
+            hints=["only one"],  # min_length=2
+        )
+
+
+# ---------------------------------------------------------------------------
+# ActivityReviewOutput constraints
+# ---------------------------------------------------------------------------
+
+
+def test_activity_review_score_must_be_0_to_100():
+    """score is bounded 0–100."""
+    with pytest.raises(ValidationError):
+        ActivityReviewOutput(
+            score=101.0,  # le=100
+            rationale="R" * 50,
+            strengths=["s1", "s2"],
+            improvements=["i1", "i2"],
+            tips=["t1", "t2"],
+            mastery_decision="meets",
+        )
+
+
+def test_activity_review_valid():
+    """Valid ActivityReviewOutput passes validation."""
+    review = ActivityReviewOutput(
+        score=85.0,
+        rationale="R" * 50,
+        strengths=["s1", "s2"],
+        improvements=["i1", "i2"],
+        tips=["t1", "t2"],
+        mastery_decision="meets",
+    )
+    assert review.score == 85.0
+    assert review.mastery_decision == "meets"
+
+
+# ---------------------------------------------------------------------------
+# AgentContext
+# ---------------------------------------------------------------------------
+
+
+def test_agent_context_dataclass():
+    """AgentContext dataclass holds db, user_id, course_instance_id."""
+    from unittest.mock import MagicMock
+
+    db = MagicMock()
+    ctx = AgentContext(db=db, user_id="u-123", course_instance_id="c-456")
+    assert ctx.db is db
+    assert ctx.user_id == "u-123"
+    assert ctx.course_instance_id == "c-456"

--- a/backend/tests/test_generation_pipeline.py
+++ b/backend/tests/test_generation_pipeline.py
@@ -1,0 +1,372 @@
+"""Integration tests for the generation pipeline (generation.py).
+
+
+All LLM agents and DB sessions are mocked — no real API calls or DB connections.
+
+When modifying generation.py:
+- New agent call added: add a patch and a test asserting the data is stored in DB
+- Commit timing changes: update mock_db.commit.call_count assertions
+- Skip logic changes: update test_skips_if_already_complete
+- New SSE events: update test_broadcasts_correct_events_in_order
+- generate_course_background generates more than lesson 0: add more side_effect entries
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.generation import _generate_single_objective, generate_course_background
+from tests.conftest import _auto_id_add
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _no_lesson_result():
+    """Mock execute() result that returns None for scalar_one_or_none()."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = None
+    return r
+
+
+def _course_result(course):
+    """Mock execute() result that returns `course` for scalar_one()."""
+    r = MagicMock()
+    r.scalar_one.return_value = course
+    return r
+
+
+def _agent_patches(sample_plan, sample_content, sample_activity_spec):
+    """Return a context manager that patches all three generation agents."""
+    return (
+        patch("app.services.generation.run_lesson_planner", AsyncMock(return_value=sample_plan)),
+        patch("app.services.generation.run_lesson_writer", AsyncMock(return_value=sample_content)),
+        patch("app.services.generation.run_activity_creator", AsyncMock(return_value=sample_activity_spec)),
+    )
+
+
+COURSE_ID = "aaaaaaaa-0000-0000-0000-000000000000"
+USER_ID = "user-0000"
+OBJECTIVES = ["Understand variables", "Understand loops"]
+DESCRIPTION = "Intro to Python"
+
+
+# ---------------------------------------------------------------------------
+# _generate_single_objective — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_happy_path_returns_true(
+    patch_background_session, patch_broadcast, sample_plan, sample_content, sample_activity_spec
+):
+    """Full pipeline succeeds and returns True."""
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(return_value=_no_lesson_result())
+
+    p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
+    with p1, p2, p3:
+        result = await _generate_single_objective(
+            COURSE_ID, USER_ID, 0, OBJECTIVES[0], DESCRIPTION,
+            OBJECTIVES, None, asyncio.Semaphore(1),
+        )
+
+    assert result is True
+
+
+async def test_lesson_and_activity_rows_added(
+    patch_background_session, patch_broadcast, sample_plan, sample_content, sample_activity_spec
+):
+    """DB.add called at least twice: once for Lesson, once for Activity."""
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(return_value=_no_lesson_result())
+
+    p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
+    with p1, p2, p3:
+        await _generate_single_objective(
+            COURSE_ID, USER_ID, 0, OBJECTIVES[0], DESCRIPTION,
+            OBJECTIVES, None, asyncio.Semaphore(1),
+        )
+
+    assert mock_db.add.call_count >= 2
+
+
+async def test_lesson_content_stored(
+    patch_background_session, patch_broadcast, sample_plan, sample_content, sample_activity_spec
+):
+    """lesson.lesson_content is set to sample_content.lesson_body."""
+    from app.db.models import Lesson
+
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(return_value=_no_lesson_result())
+
+    added_objects = []
+    mock_db.add.side_effect = lambda obj: added_objects.append(obj)
+
+    p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
+    with p1, p2, p3:
+        await _generate_single_objective(
+            COURSE_ID, USER_ID, 0, OBJECTIVES[0], DESCRIPTION,
+            OBJECTIVES, None, asyncio.Semaphore(1),
+        )
+
+    lessons = [o for o in added_objects if isinstance(o, Lesson)]
+    assert len(lessons) == 1
+    assert lessons[0].lesson_content == sample_content.lesson_body
+
+
+async def test_activity_spec_stored_as_dict(
+    patch_background_session, patch_broadcast, sample_plan, sample_content, sample_activity_spec
+):
+    """activity.activity_spec equals sample_activity_spec.model_dump()."""
+    from app.db.models import Activity
+
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(return_value=_no_lesson_result())
+
+    added_objects = []
+    mock_db.add.side_effect = lambda obj: added_objects.append(obj)
+
+    p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
+    with p1, p2, p3:
+        await _generate_single_objective(
+            COURSE_ID, USER_ID, 0, OBJECTIVES[0], DESCRIPTION,
+            OBJECTIVES, None, asyncio.Semaphore(1),
+        )
+
+    activities = [o for o in added_objects if isinstance(o, Activity)]
+    assert len(activities) == 1
+    assert activities[0].activity_spec == sample_activity_spec.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# _generate_single_objective — lesson status
+# ---------------------------------------------------------------------------
+
+
+async def test_objective_0_status_is_unlocked(
+    patch_background_session, patch_broadcast, sample_plan, sample_content, sample_activity_spec
+):
+    """First lesson (objective_index=0) gets status='unlocked'."""
+    from app.db.models import Lesson
+
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(return_value=_no_lesson_result())
+
+    added_objects = []
+    mock_db.add.side_effect = lambda obj: added_objects.append(obj)
+
+    p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
+    with p1, p2, p3:
+        await _generate_single_objective(
+            COURSE_ID, USER_ID, 0, OBJECTIVES[0], DESCRIPTION,
+            OBJECTIVES, None, asyncio.Semaphore(1),
+        )
+
+    lessons = [o for o in added_objects if isinstance(o, Lesson)]
+    assert lessons[0].status == "unlocked"
+
+
+async def test_objective_1_status_is_locked(
+    patch_background_session, patch_broadcast, sample_plan, sample_content, sample_activity_spec
+):
+    """Subsequent lessons (objective_index > 0) get status='locked'."""
+    from app.db.models import Lesson
+
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(return_value=_no_lesson_result())
+
+    added_objects = []
+    mock_db.add.side_effect = lambda obj: added_objects.append(obj)
+
+    p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
+    with p1, p2, p3:
+        await _generate_single_objective(
+            COURSE_ID, USER_ID, 1, OBJECTIVES[1], DESCRIPTION,
+            OBJECTIVES, None, asyncio.Semaphore(1),
+        )
+
+    lessons = [o for o in added_objects if isinstance(o, Lesson)]
+    assert lessons[0].status == "locked"
+
+
+# ---------------------------------------------------------------------------
+# _generate_single_objective — skip logic
+# ---------------------------------------------------------------------------
+
+
+async def test_skips_if_already_complete(patch_background_session, patch_broadcast, sample_lesson):
+    """When an existing lesson has content and activities, all agents are skipped."""
+    from app.db.models import Activity
+
+    mock_db = patch_background_session
+    sample_lesson.lesson_content = "existing content"
+    existing_activity = Activity()
+    existing_activity.id = "cccccccc-0000-0000-0000-000000000000"
+    sample_lesson.activities = [existing_activity]
+
+    existing_result = MagicMock()
+    existing_result.scalar_one_or_none.return_value = sample_lesson
+    mock_db.execute = AsyncMock(return_value=existing_result)
+
+    planner_mock = AsyncMock()
+    with patch("app.services.generation.run_lesson_planner", planner_mock):
+        result = await _generate_single_objective(
+            COURSE_ID, USER_ID, 0, OBJECTIVES[0], DESCRIPTION,
+            OBJECTIVES, None, asyncio.Semaphore(1),
+        )
+
+    assert result is True
+    planner_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _generate_single_objective — error handling
+# ---------------------------------------------------------------------------
+
+
+async def test_returns_false_on_agent_error(patch_background_session, patch_broadcast):
+    """When an agent raises, _generate_single_objective returns False (no re-raise)."""
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(return_value=_no_lesson_result())
+
+    with patch("app.services.generation.run_lesson_planner", AsyncMock(side_effect=RuntimeError("LLM failed"))):
+        result = await _generate_single_objective(
+            COURSE_ID, USER_ID, 0, OBJECTIVES[0], DESCRIPTION,
+            OBJECTIVES, None, asyncio.Semaphore(1),
+        )
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _generate_single_objective — SSE events
+# ---------------------------------------------------------------------------
+
+
+async def test_broadcasts_correct_events_in_order(
+    patch_background_session, patch_broadcast, sample_plan, sample_content, sample_activity_spec
+):
+    """lesson_planned, lesson_written, activity_created are broadcast in that order."""
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(return_value=_no_lesson_result())
+
+    p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
+    with p1, p2, p3:
+        await _generate_single_objective(
+            COURSE_ID, USER_ID, 0, OBJECTIVES[0], DESCRIPTION,
+            OBJECTIVES, None, asyncio.Semaphore(1),
+        )
+
+    events = [call.args[1] for call in patch_broadcast.call_args_list]
+    assert "lesson_planned" in events
+    assert "lesson_written" in events
+    assert "activity_created" in events
+    assert events.index("lesson_planned") < events.index("lesson_written")
+    assert events.index("lesson_written") < events.index("activity_created")
+
+
+# ---------------------------------------------------------------------------
+# generate_course_background
+#
+# Note: this function calls get_background_session() twice:
+#   1. Inside _generate_single_objective (lesson/activity creation)
+#   2. After that, to fetch the course and transition state
+# So mock_db.execute needs side_effect=[no_lesson_result, course_result].
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_course_background_transitions_to_active_on_success(
+    patch_background_session, patch_broadcast, sample_plan, sample_content, sample_activity_spec, sample_course
+):
+    """On success, course transitions to 'active' then 'in_progress'."""
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(side_effect=[_no_lesson_result(), _course_result(sample_course)])
+
+    transition_mock = AsyncMock(
+        side_effect=lambda db, course, status: setattr(course, "status", status) or course
+    )
+
+    p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
+    with p1, p2, p3, patch("app.services.generation.transition_course", transition_mock):
+        await generate_course_background(
+            COURSE_ID, USER_ID, OBJECTIVES, DESCRIPTION,
+        )
+
+    transition_calls = [c.args[2] for c in transition_mock.call_args_list]
+    assert "active" in transition_calls
+    assert "in_progress" in transition_calls
+
+
+async def test_generate_course_background_transitions_to_generation_failed_on_error(
+    patch_background_session, patch_broadcast, sample_course
+):
+    """When lesson 0 generation fails, course transitions to 'generation_failed'."""
+    mock_db = patch_background_session
+    # _generate_single_objective fails, then generate_course_background opens another session
+    mock_db.execute = AsyncMock(side_effect=[_no_lesson_result(), _course_result(sample_course)])
+
+    transition_mock = AsyncMock(
+        side_effect=lambda db, course, status: setattr(course, "status", status) or course
+    )
+
+    with patch("app.services.generation.run_lesson_planner", AsyncMock(side_effect=RuntimeError("boom"))), \
+         patch("app.services.generation.transition_course", transition_mock):
+        await generate_course_background(
+            COURSE_ID, USER_ID, OBJECTIVES, DESCRIPTION,
+        )
+
+    transition_calls = [c.args[2] for c in transition_mock.call_args_list]
+    assert "generation_failed" in transition_calls
+
+
+async def test_generate_course_background_broadcasts_generation_complete(
+    patch_background_session, patch_broadcast, sample_plan, sample_content, sample_activity_spec, sample_course
+):
+    """generation_complete is always broadcast, even on failure."""
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(side_effect=[_no_lesson_result(), _course_result(sample_course)])
+
+    p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
+    with p1, p2, p3, patch("app.services.generation.transition_course", AsyncMock()):
+        await generate_course_background(
+            COURSE_ID, USER_ID, OBJECTIVES, DESCRIPTION,
+        )
+
+    events = [c.args[1] for c in patch_broadcast.call_args_list]
+    assert "generation_complete" in events
+
+
+async def test_generate_course_background_broadcasts_generation_complete_on_failure(
+    patch_background_session, patch_broadcast, sample_course
+):
+    """generation_complete is broadcast even when generation fails."""
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(side_effect=[_no_lesson_result(), _course_result(sample_course)])
+
+    with patch("app.services.generation.run_lesson_planner", AsyncMock(side_effect=RuntimeError("boom"))), \
+         patch("app.services.generation.transition_course", AsyncMock()):
+        await generate_course_background(
+            COURSE_ID, USER_ID, OBJECTIVES, DESCRIPTION,
+        )
+
+    events = [c.args[1] for c in patch_broadcast.call_args_list]
+    assert "generation_complete" in events
+
+
+async def test_generate_course_background_sets_generated_description(
+    patch_background_session, patch_broadcast, sample_plan, sample_content, sample_activity_spec, sample_course
+):
+    """course.generated_description is set to the input description."""
+    mock_db = patch_background_session
+    mock_db.execute = AsyncMock(side_effect=[_no_lesson_result(), _course_result(sample_course)])
+
+    p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
+    with p1, p2, p3, patch("app.services.generation.transition_course", AsyncMock()):
+        await generate_course_background(
+            COURSE_ID, USER_ID, OBJECTIVES, DESCRIPTION,
+        )
+
+    assert sample_course.generated_description == DESCRIPTION

--- a/backend/tests/test_generation_pipeline.py
+++ b/backend/tests/test_generation_pipeline.py
@@ -103,7 +103,12 @@ async def test_lesson_content_stored(
     mock_db.execute = AsyncMock(return_value=_no_lesson_result())
 
     added_objects = []
-    mock_db.add.side_effect = lambda obj: added_objects.append(obj)
+
+    def _collect(obj):
+        _auto_id_add(obj)
+        added_objects.append(obj)
+
+    mock_db.add.side_effect = _collect
 
     p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
     with p1, p2, p3:
@@ -127,7 +132,12 @@ async def test_activity_spec_stored_as_dict(
     mock_db.execute = AsyncMock(return_value=_no_lesson_result())
 
     added_objects = []
-    mock_db.add.side_effect = lambda obj: added_objects.append(obj)
+
+    def _collect(obj):
+        _auto_id_add(obj)
+        added_objects.append(obj)
+
+    mock_db.add.side_effect = _collect
 
     p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
     with p1, p2, p3:
@@ -156,7 +166,12 @@ async def test_objective_0_status_is_unlocked(
     mock_db.execute = AsyncMock(return_value=_no_lesson_result())
 
     added_objects = []
-    mock_db.add.side_effect = lambda obj: added_objects.append(obj)
+
+    def _collect(obj):
+        _auto_id_add(obj)
+        added_objects.append(obj)
+
+    mock_db.add.side_effect = _collect
 
     p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
     with p1, p2, p3:
@@ -179,7 +194,12 @@ async def test_objective_1_status_is_locked(
     mock_db.execute = AsyncMock(return_value=_no_lesson_result())
 
     added_objects = []
-    mock_db.add.side_effect = lambda obj: added_objects.append(obj)
+
+    def _collect(obj):
+        _auto_id_add(obj)
+        added_objects.append(obj)
+
+    mock_db.add.side_effect = _collect
 
     p1, p2, p3 = _agent_patches(sample_plan, sample_content, sample_activity_spec)
     with p1, p2, p3:

--- a/backend/tests/test_generation_tracker.py
+++ b/backend/tests/test_generation_tracker.py
@@ -1,0 +1,148 @@
+"""Unit tests for the SSE generation tracker (generation_tracker.py).
+
+No mocks needed — tests the real in-memory module.
+Module-level state (_active_tasks, _subscribers) is reset between tests
+via the autouse `reset_tracker` fixture.
+"""
+
+import asyncio
+
+import pytest
+
+from app.services import generation_tracker
+from app.services.generation_tracker import (
+    broadcast,
+    cleanup,
+    is_running,
+    start_generation,
+    subscribe,
+    unsubscribe,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_tracker():
+    """Clear module-level state before each test to prevent cross-test pollution."""
+    generation_tracker._active_tasks.clear()
+    generation_tracker._subscribers.clear()
+    yield
+    generation_tracker._active_tasks.clear()
+    generation_tracker._subscribers.clear()
+
+
+# ---------------------------------------------------------------------------
+# broadcast / subscribe / unsubscribe
+# ---------------------------------------------------------------------------
+
+
+async def test_broadcast_delivers_to_subscriber():
+    """Messages sent via broadcast are received by the subscribed queue."""
+    queue = subscribe("course-1")
+    await broadcast("course-1", "lesson_planned", {"objective_index": 0})
+
+    msg = queue.get_nowait()
+    assert msg["event"] == "lesson_planned"
+    assert msg["data"]["objective_index"] == 0
+
+    unsubscribe("course-1", queue)
+
+
+async def test_broadcast_no_subscribers_does_not_raise():
+    """broadcast with no subscribers completes silently."""
+    await broadcast("nonexistent-course", "some_event", {})
+
+
+async def test_unsubscribe_removes_queue():
+    """After unsubscribe, the queue receives no further messages."""
+    queue = subscribe("course-2")
+    unsubscribe("course-2", queue)
+    await broadcast("course-2", "lesson_planned", {})
+    assert queue.empty()
+
+
+async def test_multiple_subscribers_all_receive():
+    """All subscribers for a key receive the same broadcast."""
+    q1 = subscribe("course-3")
+    q2 = subscribe("course-3")
+    await broadcast("course-3", "activity_created", {"activity_id": "abc"})
+
+    assert not q1.empty()
+    assert not q2.empty()
+    assert q1.get_nowait()["event"] == "activity_created"
+    assert q2.get_nowait()["event"] == "activity_created"
+
+    unsubscribe("course-3", q1)
+    unsubscribe("course-3", q2)
+
+
+async def test_broadcast_includes_empty_data_when_none():
+    """broadcast normalises None data to an empty dict."""
+    queue = subscribe("course-4")
+    await broadcast("course-4", "generation_complete", None)
+
+    msg = queue.get_nowait()
+    assert msg["data"] == {}
+    unsubscribe("course-4", queue)
+
+
+# ---------------------------------------------------------------------------
+# is_running / start_generation / cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_is_running_false_for_unknown_key():
+    """is_running returns False for a key with no active task."""
+    assert is_running("no-such-task") is False
+
+
+async def test_start_generation_tracks_running_task():
+    """is_running returns True while a long-running task is in flight."""
+    event = asyncio.Event()
+
+    async def long_running():
+        await event.wait()
+
+    task = start_generation("task-1", long_running())
+    assert is_running("task-1") is True
+
+    event.set()
+    await task
+
+
+async def test_start_generation_raises_if_already_running():
+    """Calling start_generation for a running key raises RuntimeError."""
+    event = asyncio.Event()
+
+    async def long_running():
+        await event.wait()
+
+    task = start_generation("task-2", long_running())
+
+    with pytest.raises(RuntimeError, match="already running"):
+        start_generation("task-2", long_running())
+
+    event.set()
+    await task
+
+
+async def test_cleanup_removes_task_tracking():
+    """cleanup() removes the key from active tasks."""
+    async def noop():
+        pass
+
+    task = start_generation("task-3", noop())
+    await task
+    # done_callback fires cleanup automatically after task completes
+    assert is_running("task-3") is False
+
+
+async def test_is_running_false_after_task_completes():
+    """is_running returns False once a task finishes naturally."""
+    async def quick():
+        pass
+
+    task = start_generation("task-4", quick())
+    await task
+    # Give done_callback a chance to run
+    await asyncio.sleep(0)
+    assert is_running("task-4") is False

--- a/backend/tests/test_generation_tracker.py
+++ b/backend/tests/test_generation_tracker.py
@@ -118,8 +118,11 @@ async def test_start_generation_raises_if_already_running():
 
     task = start_generation("task-2", long_running())
 
+    # Close the coroutine explicitly to avoid "coroutine never awaited" warning
+    coro = long_running()
     with pytest.raises(RuntimeError, match="already running"):
-        start_generation("task-2", long_running())
+        start_generation("task-2", coro)
+    coro.close()
 
     event.set()
     await task

--- a/backend/tests/test_state_machine.py
+++ b/backend/tests/test_state_machine.py
@@ -1,0 +1,236 @@
+"""Unit tests for the course state machine (progression.py).
+
+All tests use mock_db directly — no patching needed since these functions
+accept AsyncSession as a parameter.
+
+When modifying progression.py:
+- New transition edge → add a test following the existing pattern
+- New guard condition → add tests for both pass and fail cases
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.progression import (
+    InvalidTransitionError,
+    check_all_lessons_completed,
+    transition_course,
+    unlock_next_lesson,
+)
+
+
+# ---------------------------------------------------------------------------
+# transition_course — valid transitions
+# ---------------------------------------------------------------------------
+
+
+async def test_draft_to_generating_succeeds(mock_db, sample_course):
+    """Guard 'has_objectives' passes when input_objectives is non-empty."""
+    sample_course.status = "draft"
+    result = await transition_course(mock_db, sample_course, "generating")
+    assert result.status == "generating"
+    mock_db.flush.assert_called_once()
+
+
+async def test_generating_to_active_succeeds_with_content(mock_db, sample_course, sample_lesson):
+    """Guard 'all_content_generated' passes when all lessons have content."""
+    sample_course.status = "generating"
+    sample_lesson.lesson_content = "Some lesson text"
+    sample_course.lessons = [sample_lesson]
+    result = await transition_course(mock_db, sample_course, "active")
+    assert result.status == "active"
+
+
+async def test_active_to_in_progress_always_succeeds(mock_db, sample_course):
+    """Guard 'always' — no condition required."""
+    sample_course.status = "active"
+    result = await transition_course(mock_db, sample_course, "in_progress")
+    assert result.status == "in_progress"
+
+
+async def test_generation_failed_to_generating_retry(mock_db, sample_course):
+    """Retry path: generation_failed → generating uses 'always' guard."""
+    sample_course.status = "generation_failed"
+    result = await transition_course(mock_db, sample_course, "generating")
+    assert result.status == "generating"
+
+
+async def test_generating_to_generation_failed(mock_db, sample_course):
+    """Failure path: generating → generation_failed uses 'always' guard."""
+    sample_course.status = "generating"
+    result = await transition_course(mock_db, sample_course, "generation_failed")
+    assert result.status == "generation_failed"
+
+
+# ---------------------------------------------------------------------------
+# transition_course — guard failures
+# ---------------------------------------------------------------------------
+
+
+async def test_draft_to_generating_fails_without_objectives(mock_db, sample_course):
+    """Guard 'has_objectives' blocks transition when input_objectives is empty."""
+    sample_course.status = "draft"
+    sample_course.input_objectives = []
+    with pytest.raises(InvalidTransitionError, match="has_objectives"):
+        await transition_course(mock_db, sample_course, "generating")
+
+
+async def test_generating_to_active_fails_without_lesson_content(mock_db, sample_course, sample_lesson):
+    """Guard 'all_content_generated' fails if any lesson has null content."""
+    sample_course.status = "generating"
+    sample_lesson.lesson_content = None
+    sample_course.lessons = [sample_lesson]
+    with pytest.raises(InvalidTransitionError, match="all_content_generated"):
+        await transition_course(mock_db, sample_course, "active")
+
+
+async def test_generating_to_active_fails_with_no_lessons(mock_db, sample_course):
+    """Guard 'all_content_generated' fails when there are zero lessons."""
+    sample_course.status = "generating"
+    sample_course.lessons = []
+    with pytest.raises(InvalidTransitionError, match="all_content_generated"):
+        await transition_course(mock_db, sample_course, "active")
+
+
+async def test_in_progress_to_awaiting_fails_when_lesson_not_completed(mock_db, sample_course, sample_lesson):
+    """Guard 'all_lessons_completed' fails if any lesson is not completed."""
+    sample_course.status = "in_progress"
+    sample_lesson.status = "unlocked"
+    sample_course.lessons = [sample_lesson]
+    with pytest.raises(InvalidTransitionError, match="all_lessons_completed"):
+        await transition_course(mock_db, sample_course, "awaiting_assessment")
+
+
+async def test_in_progress_to_awaiting_succeeds_when_all_completed(mock_db, sample_course, sample_lesson):
+    """Guard 'all_lessons_completed' passes when all lessons are completed."""
+    sample_course.status = "in_progress"
+    sample_lesson.status = "completed"
+    sample_course.lessons = [sample_lesson]
+    result = await transition_course(mock_db, sample_course, "awaiting_assessment")
+    assert result.status == "awaiting_assessment"
+
+
+# ---------------------------------------------------------------------------
+# transition_course — invalid paths
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_transition_raises(mock_db, sample_course):
+    """Non-existent transition raises InvalidTransitionError with clear message."""
+    sample_course.status = "draft"
+    with pytest.raises(InvalidTransitionError, match="Cannot transition from 'draft' to 'completed'"):
+        await transition_course(mock_db, sample_course, "completed")
+
+
+async def test_backward_transition_raises(mock_db, sample_course):
+    """No backward transitions exist (e.g. active → draft)."""
+    sample_course.status = "active"
+    with pytest.raises(InvalidTransitionError):
+        await transition_course(mock_db, sample_course, "draft")
+
+
+# ---------------------------------------------------------------------------
+# unlock_next_lesson
+# ---------------------------------------------------------------------------
+
+
+async def test_unlock_next_lesson_creates_new_row(mock_db, sample_course):
+    """When no lesson row exists for next_index, a new one is created with status=unlocked."""
+    course_result = MagicMock()
+    course_result.scalar_one.return_value = sample_course
+    lesson_result = MagicMock()
+    lesson_result.scalar_one_or_none.return_value = None
+    mock_db.execute = AsyncMock(side_effect=[course_result, lesson_result])
+
+    added_objects = []
+    mock_db.add.side_effect = lambda obj: added_objects.append(obj)
+
+    lesson = await unlock_next_lesson(mock_db, sample_course.id, completed_index=0)
+
+    assert lesson is not None
+    assert lesson.objective_index == 1
+    assert lesson.status == "unlocked"
+    mock_db.add.assert_called_once()
+
+
+async def test_unlock_next_lesson_returns_none_at_last_objective(mock_db, sample_course):
+    """Returns None when completed_index is the last objective."""
+    sample_course.input_objectives = ["obj 0"]  # only one objective
+    course_result = MagicMock()
+    course_result.scalar_one.return_value = sample_course
+    mock_db.execute = AsyncMock(return_value=course_result)
+
+    result = await unlock_next_lesson(mock_db, sample_course.id, completed_index=0)
+    assert result is None
+
+
+async def test_unlock_next_lesson_unlocks_existing_locked_row(mock_db, sample_course, sample_lesson):
+    """When a locked row already exists for next_index, status is updated to unlocked."""
+    sample_lesson.objective_index = 1
+    sample_lesson.status = "locked"
+    course_result = MagicMock()
+    course_result.scalar_one.return_value = sample_course
+    lesson_result = MagicMock()
+    lesson_result.scalar_one_or_none.return_value = sample_lesson
+    mock_db.execute = AsyncMock(side_effect=[course_result, lesson_result])
+
+    result = await unlock_next_lesson(mock_db, sample_course.id, completed_index=0)
+    assert result.status == "unlocked"
+
+
+async def test_unlock_next_lesson_returns_already_unlocked_row(mock_db, sample_course, sample_lesson):
+    """When a row already exists with status=unlocked, it is returned unchanged."""
+    sample_lesson.objective_index = 1
+    sample_lesson.status = "unlocked"
+    course_result = MagicMock()
+    course_result.scalar_one.return_value = sample_course
+    lesson_result = MagicMock()
+    lesson_result.scalar_one_or_none.return_value = sample_lesson
+    mock_db.execute = AsyncMock(side_effect=[course_result, lesson_result])
+
+    result = await unlock_next_lesson(mock_db, sample_course.id, completed_index=0)
+    assert result.status == "unlocked"
+    mock_db.add.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# check_all_lessons_completed
+# ---------------------------------------------------------------------------
+
+
+async def test_check_all_lessons_completed_true(mock_db):
+    """Returns True only when all lessons have status='completed'."""
+    from app.db.models import Lesson
+
+    l1, l2 = Lesson(), Lesson()
+    l1.status = "completed"
+    l2.status = "completed"
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = [l1, l2]
+    mock_db.execute = AsyncMock(return_value=result_mock)
+
+    assert await check_all_lessons_completed(mock_db, "some-course-id") is True
+
+
+async def test_check_all_lessons_completed_false_when_any_unlocked(mock_db):
+    """Returns False when any lesson has a non-completed status."""
+    from app.db.models import Lesson
+
+    l1, l2 = Lesson(), Lesson()
+    l1.status = "completed"
+    l2.status = "unlocked"
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = [l1, l2]
+    mock_db.execute = AsyncMock(return_value=result_mock)
+
+    assert await check_all_lessons_completed(mock_db, "some-course-id") is False
+
+
+async def test_check_all_lessons_completed_false_when_empty(mock_db):
+    """Returns False (not True) when there are zero lessons."""
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = []
+    mock_db.execute = AsyncMock(return_value=result_mock)
+
+    assert await check_all_lessons_completed(mock_db, "some-course-id") is False


### PR DESCRIPTION
## Summary

- **Test suite** — adds 59 pytest tests covering the generation pipeline, course state machine, SSE tracker, and agent schema contracts. No real API key or DB required — all external calls are mocked.
- **CI** — new `ci.yml` workflow runs the test suite on every PR to `main`. This is a required status check; PRs cannot merge until tests pass.
- **Deploy** — new `deploy.yml` workflow runs tests then builds/pushes the Docker image to ECR and triggers App Runner on every merge to `main`. Replaces the manual `infra/deploy.sh` step.
- **Docs** — README gets a `## Testing` section; CONTRIBUTING gets a testing step, CI/CD section, and a "no failing tests" rule.
- **`.gitignore`** — adds `*.tfstate.*` to catch timestamped Terraform backup files.

## Test plan

- [ ] Merge triggers `CI / Run tests` check — confirm it passes
- [ ] After merge to `main`, confirm `Deploy to AWS / Run tests` passes and `Build and deploy` pushes to ECR and triggers App Runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)