### PR TITLE
Anchor activities to learner's real work instead of hypothetical scenarios

### DIFF
--- a/app/courses/ai-leadership/course.json
+++ b/app/courses/ai-leadership/course.json
@@ -2,7 +2,7 @@
   "courseId": "ai-leadership",
   "version": "1.0.0",
   "name": "AI Leadership",
-  "description": "Learn how generative and agentic AI works at a practical level, apply it to real tasks, improve ideation and learning workflows, and define an ethics-informed approach to AI use.",
+  "description": "Learn how generative and agentic AI works at a practical level, apply it to real tasks, improve ideation and learning workflows, and define an ethics-informed approach to AI use. Every activity applies AI skills directly to each learner's real tasks, projects, and personal workflow.",
   "learningObjectives": [
     "I can understand the basic math and science concepts that make generative and agentic AI tools work",
     "I can use AI on appropriate tasks to do better work in less time with fewer resources.",

--- a/app/courses/foundations/course.json
+++ b/app/courses/foundations/course.json
@@ -2,7 +2,7 @@
   "courseId": "foundations",
   "version": "1.0.0",
   "name": "Foundations",
-  "description": "Build core professional and digital habits: communicate clearly, use common workplace tools, stay organized, manage time, measure impact, and establish a digital portfolio.",
+  "description": "Build core professional and digital habits: communicate clearly, use common workplace tools, stay organized, manage time, measure impact, and establish a digital portfolio. Every activity asks learners to apply these skills directly to their own professional goals, real tools, and work in progress.",
   "learningObjectives": [
     "I can communicate my professional purpose and motivation in writing, digitally, quickly, clearly, and effectively using assistive tools.",
     "I can use the technology that's commonly used to accomplish the job that I want to be able to do",

--- a/app/courses/success-skills/course.json
+++ b/app/courses/success-skills/course.json
@@ -2,7 +2,7 @@
   "courseId": "success-skills",
   "version": "1.0.0",
   "name": "Success Skills",
-  "description": "Develop career success fundamentals: personal branding, wage planning and advocacy, networking with mentors/peers, healthy conflict navigation, and clear, compelling professional presentation.",
+  "description": "Develop career success fundamentals: personal branding, wage planning and advocacy, networking with mentors/peers, healthy conflict navigation, and clear, compelling professional presentation. Every activity asks learners to act on their own real career situation, personal brand assets, and professional network.",
   "learningObjectives": [
     "I can create a compelling personal brand to help me earn the opportunities I seek",
     "I can plan and advocate for Living Wages that help me realize my lifestyle goals",

--- a/app/courses/wordpress/course.json
+++ b/app/courses/wordpress/course.json
@@ -2,7 +2,7 @@
   "courseId": "wordpress",
   "version": "1.0.0",
   "name": "WordPress",
-  "description": "Explore careers in the WordPress ecosystem while building job-aligned web content, using LLMs responsibly, understanding open-source fundamentals, and navigating full-stack concepts with AI support.",
+  "description": "Explore careers in the WordPress ecosystem while building job-aligned web content, using LLMs responsibly, understanding open-source fundamentals, and navigating full-stack concepts with AI support. Every activity produces a real deliverable tied to each learner's personal job interests and portfolio.",
   "learningObjectives": [
     "I can articulate why I'm uniquely interested in WordPress, and what skills I offer the WordPress community.",
     "I understand what jobs WordPress offers, what roles I am best suited for now, and what roles I hope to grow into.",

--- a/backend/src/app/agents/activity_creator.py
+++ b/backend/src/app/agents/activity_creator.py
@@ -21,11 +21,12 @@ activity_creator = Agent(
         "- hints: 2-5 scaffolding hints that guide without giving the answer\n\n"
         "The activity should directly test the learning objective. Make it challenging but "
         "achievable. Tailor to the learner's profile if provided.\n\n"
-        "IMPORTANT — Domain transfer: The activity seed shows the TOPIC and SKILL to test, "
-        "but you MUST set the activity in a DIFFERENT real-world domain/scenario than the one "
-        "in the seed. For example, if the seed uses a 'user profile' scenario, use something "
-        "unrelated like a 'weather tracker' or 'recipe book'. This forces learners to transfer "
-        "knowledge rather than copy the worked example from the lesson."
+        "IMPORTANT — Personal application: The activity seed shows the TOPIC and SKILL to test. "
+        "You MUST anchor the activity in the learner's REAL personal work, projects, or career "
+        "goals as described in their learner profile. Ask the learner to apply the skill directly "
+        "to something they are actually building, doing, or pursuing. If no profile is available, "
+        "use the course description's goals as context and frame the activity around the learner's "
+        "own real-world situation — not a hypothetical or prefabricated example."
     ),
 )
 


### PR DESCRIPTION
## Summary
- Replaced the Activity Creator agent's \"domain transfer\" rule with a \"personal application\" rule — activities now connect to the learner's real work, projects, and career goals instead of unrelated hypothetical scenarios
- Updated all four course descriptions (foundations, success-skills, wordpress, ai-leadership) to reinforce this intent at the Lesson Planner stage, so activity seeds are also framed around personal context before the Activity Creator expands them

## Root cause
The Activity Creator system prompt contained an explicit directive to use a *different* domain/scenario than the lesson's worked examples. This was designed to prevent copying, but produced generic hypotheticals (\"weather tracker\", \"recipe book\") disconnected from the learner's actual work.

## Test plan
- [ ] Enroll a learner with a filled-out profile (e.g., \"I'm building a personal finance tracker\") and generate a course — activities should reference their stated work
- [ ] Generate with an empty profile — activities should prompt the learner to apply the skill to something real *they* choose, not a prefabricated example
- [ ] Run test suite: `cd backend && PYTHONPATH=src ANTHROPIC_API_KEY=test-key uv run pytest tests/ -v` (no test changes expected — tests mock agent outputs, not prompts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)