### PR TITLE
Fix lesson 2 not generating after passing lesson 1 activity

### DIFF
--- a/backend/src/app/services/activity_review.py
+++ b/backend/src/app/services/activity_review.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import selectinload
 
 from app.agents.activity_reviewer import run_activity_reviewer
 from app.agents.logging import AgentContext
-from app.db.models import Activity, CourseInstance, Lesson
+from app.db.models import Activity, CourseInstance, Lesson, User
 from app.db.session import get_background_session
 from app.services.generation import generate_lesson_on_demand
 from app.services.generation_tracker import broadcast, is_running, start_generation
@@ -37,7 +37,7 @@ async def review_activity_background(
     key = review_key(activity_id)
 
     # Capture generation data before entering the DB session
-    next_lesson_to_generate: tuple[int, list[str], str] | None = None
+    next_lesson_to_generate: tuple[int, list[str], str, dict | None] | None = None
 
     try:
         async with get_background_session() as db:
@@ -82,10 +82,23 @@ async def review_activity_background(
 
                 # If the unlocked lesson has no content yet, schedule on-demand generation
                 if next_lesson and next_lesson.lesson_content is None:
+                    # Load learner profile for personalized generation
+                    profile_result = await db.execute(
+                        select(User)
+                        .where(User.id == user_id)
+                        .options(selectinload(User.learner_profile))
+                    )
+                    user_obj = profile_result.scalar_one_or_none()
+                    learner_profile = (
+                        user_obj.learner_profile.to_agent_dict()
+                        if user_obj and user_obj.learner_profile
+                        else None
+                    )
                     next_lesson_to_generate = (
                         next_lesson.objective_index,
                         list(course.input_objectives),
                         course.generated_description or course.input_description or "",
+                        learner_profile,
                     )
 
                 if await check_all_lessons_completed(db, course.id):
@@ -108,7 +121,7 @@ async def review_activity_background(
 
         # Kick off on-demand generation after the session has committed
         if next_lesson_to_generate:
-            next_index, objectives, description = next_lesson_to_generate
+            next_index, objectives, description, learner_profile = next_lesson_to_generate
             gen_key = f"lesson-gen-{course_id}-{next_index}"
             if not is_running(gen_key):
                 logger.info(
@@ -121,6 +134,7 @@ async def review_activity_background(
                     objective_index=next_index,
                     objectives=objectives,
                     description=description,
+                    learner_profile=learner_profile,
                 ))
 
         # Broadcast review result AFTER commit

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -72,7 +72,7 @@ export function ActivityPage() {
     activity.mastery_decision === 'meets' ||
     activity.mastery_decision === 'exceeds';
 
-  const isLast = lessonIndex === course.lessons.length - 1;
+  const isLast = lessonIndex === course.input_objectives.length - 1;
 
   function connectSSE(activityId: string) {
     cleanupRef.current?.();

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -1,16 +1,25 @@
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useCourseStore } from '@/stores/course-store';
 import { MarkdownRenderer } from '@/components/lesson/MarkdownRenderer';
 import { LessonNav } from '@/components/lesson/LessonNav';
 
 export function LessonPage() {
-  const { index } = useParams<{ index: string }>();
-  const { course } = useCourseStore();
+  const { courseId, index } = useParams<{ courseId: string; index: string }>();
+  const { course, loadCourse } = useCourseStore();
   const lessonIndex = Number(index ?? 0);
 
-  if (!course) return null;
+  const lesson = course?.lessons[lessonIndex];
+  const generating = lesson && !lesson.lesson_content && lesson.status === 'unlocked';
 
-  const lesson = course.lessons[lessonIndex];
+  // Poll until on-demand lesson content arrives
+  useEffect(() => {
+    if (!generating || !courseId) return;
+    const id = setInterval(() => loadCourse(courseId), 3000);
+    return () => clearInterval(id);
+  }, [generating, courseId, loadCourse]);
+
+  if (!course) return null;
 
   if (!lesson) {
     return <p className="text-muted-foreground">Lesson not found.</p>;
@@ -29,7 +38,10 @@ export function LessonPage() {
       {lesson.lesson_content ? (
         <MarkdownRenderer content={lesson.lesson_content} />
       ) : (
-        <p className="text-muted-foreground">No content available yet.</p>
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          Generating lesson content...
+        </div>
       )}
       <LessonNav course={course} currentIndex={lessonIndex} />
     </div>


### PR DESCRIPTION
## Summary

- **Race condition fix**: `ActivityPage` computed `isLast` from `course.lessons.length`, which could be stale (1 lesson) when the user clicked "Continue" before `loadCourse` resolved — routing them straight to assessment. Changed to `course.input_objectives.length`, which is always authoritative.
- **LessonPage loading state + polling**: Replaced the static "No content available yet." with a spinner that polls `loadCourse` every 3 seconds while a lesson is `unlocked` but has no content, so the UI auto-updates when on-demand generation finishes.
- **Learner profile passed to on-demand generation**: `activity_review.py` was calling `generate_lesson_on_demand` without `learner_profile`, so all lessons after the first were generated without personalization. Now loads the `User` + `LearnerProfile` from DB and passes the profile dict.

## Test plan

- [ ] Create a course with 2+ objectives and generate lesson 1
- [ ] Submit the lesson 1 activity and pass (mastery met)
- [ ] Verify "Continue" navigates to lesson 2 (not assessment)
- [ ] Verify lesson 2 shows a spinner while generating, then displays content automatically
- [ ] Verify lesson 2 content reflects the learner's profile (if one is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)