### PR TITLE
Fix lesson_writer validation failure (key_takeaways missing)

### DIFF
--- a/backend/src/app/schemas/lesson.py
+++ b/backend/src/app/schemas/lesson.py
@@ -24,5 +24,5 @@ class LessonContentOutput(BaseModel):
     """Output from the lesson_writer agent."""
 
     lesson_title: str
-    lesson_body: str = Field(min_length=200)
     key_takeaways: list[str] = Field(min_length=3, max_length=6)
+    lesson_body: str = Field(min_length=200)


### PR DESCRIPTION
## Summary
- `lesson_writer` was consistently failing for some users because the LLM omitted `key_takeaways` from its structured output response
- Root cause: `key_takeaways` was defined *after* `lesson_body` in `LessonContentOutput` — when the lesson body is very long (~90s to generate), the model would fill the body and skip the remaining field
- Fix: reorder `key_takeaways` before `lesson_body` so it is always populated first

**Confirmed from CloudWatch logs:** user's course `9d909842` hit this exact failure — 3 attempts × ~90s each = 269s before giving up with `Exceeded maximum retries (2) for output validation`

## Test plan
- [ ] Trigger generation on a course with a content-heavy topic
- [ ] Confirm generation completes and `key_takeaways` is populated in the lesson
- [ ] Verify the affected user (`comradehiggins@gmail.com`) can retry their failed course

🤖 Generated with [Claude Code](https://claude.com/claude-code)