### PR TITLE
Fix lesson_writer omitting key_takeaways (prompt + max_tokens)

### DIFF
--- a/backend/src/app/agents/lesson_writer.py
+++ b/backend/src/app/agents/lesson_writer.py
@@ -1,4 +1,5 @@
 from pydantic_ai import Agent
+from pydantic_ai.settings import ModelSettings
 
 from app.agents.logging import AgentContext, run_agent
 from app.schemas.lesson import LessonContentOutput, LessonPlanOutput
@@ -6,10 +7,15 @@ from app.schemas.lesson import LessonContentOutput, LessonPlanOutput
 lesson_writer = Agent(
     output_type=LessonContentOutput,
     retries=2,
+    model_settings=ModelSettings(max_tokens=8000),
     system_prompt=(
-        "You are an expert educational content writer. Given a lesson plan, write a complete "
-        "lesson in Markdown.\n\n"
-        "Requirements for the lesson body:\n"
+        "You are an expert educational content writer. Given a lesson plan, write a complete lesson.\n\n"
+        "You must return all three fields:\n"
+        "  • lesson_title — the title of the lesson\n"
+        "  • key_takeaways — 3 to 6 short strings (1-2 sentences each), the most important points "
+        "the learner should remember. Do NOT embed these inside lesson_body.\n"
+        "  • lesson_body — the full lesson in Markdown (minimum 200 characters)\n\n"
+        "Requirements for lesson_body:\n"
         "- Start with a clear statement of the learning objective\n"
         "- Explain why this topic matters (real-world relevance)\n"
         "- Walk through the key concepts with clear steps and explanations\n"
@@ -17,13 +23,11 @@ lesson_writer = Agent(
         "- End with a brief recap that ties back to the objective\n"
         "- Use Markdown headings (##, ###), lists, and code blocks where appropriate\n"
         "- Write in a clear, engaging voice — teach, don't lecture\n"
-        "- Minimum 200 characters for the lesson body\n"
         "- The lesson plan includes a suggested_activity and mastery_criteria. By the end of "
         "the lesson, the learner should have everything they need to attempt the activity and "
         "plausibly meet each mastery criterion. Make this explicit: use worked examples that "
         "mirror the skill demands of the activity, and close with a note signalling what the "
         "learner is now ready to do (e.g., 'You're now ready to try [activity type]').\n\n"
-        "Also provide 3-6 concise key takeaways.\n\n"
         "Tailor tone, examples, and difficulty to the learner's profile if provided."
     ),
 )


### PR DESCRIPTION
## Summary
- Previous fix (schema field reorder) didn't work — Claude ignores JSON schema property order for tool call arguments
- Root cause was two separate issues:
  1. `key_takeaways` was buried as an afterthought (`"Also provide 3-6 concise key takeaways."`) — the model was folding them into the lesson body recap and skipping the structured field
  2. No `max_tokens` set on the agent — PydanticAI defaults to 1024 for Anthropic, leaving very little budget for long lessons
- Fix: restructure system prompt to lead with all three required fields by name, explicitly tell the model not to embed takeaways in the body, and set `max_tokens=8000`

## Test plan
- [ ] Retry generation for `comradehiggins@gmail.com` on the ai-leadership course
- [ ] Confirm `key_takeaways` is populated in the lesson response
- [ ] Confirm generation completes in a reasonable time without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)