### PR TITLE
Make site fully responsive for all screen sizes

### DIFF
--- a/frontend/src/components/activity/FeedbackDisplay.tsx
+++ b/frontend/src/components/activity/FeedbackDisplay.tsx
@@ -26,9 +26,9 @@ export function FeedbackDisplay({
         : 'text-red-600';
 
   return (
-    <div className="space-y-4 rounded-lg border p-4">
+    <div className="space-y-4 rounded-lg border p-3 sm:p-4">
       <div className="flex items-center gap-3">
-        <span className={`text-3xl font-bold ${scoreColor}`}>{score}</span>
+        <span className={`text-2xl sm:text-3xl font-bold ${scoreColor}`}>{score}</span>
         <span className="text-sm text-muted-foreground">/ 100</span>
         <Badge className={MASTERY_COLORS[mastery] ?? ''}>
           {MASTERY_LABELS[mastery] ?? mastery}

--- a/frontend/src/components/assessment/AssessmentResults.tsx
+++ b/frontend/src/components/assessment/AssessmentResults.tsx
@@ -15,8 +15,8 @@ export function AssessmentResults({ assessment }: AssessmentResultsProps) {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-4">
-        <span className={`text-4xl font-bold ${scoreColor}`}>
+      <div className="flex flex-wrap items-center gap-3 sm:gap-4">
+        <span className={`text-2xl sm:text-4xl font-bold ${scoreColor}`}>
           {Math.round(score)}
         </span>
         <span className="text-muted-foreground">/ 100</span>

--- a/frontend/src/components/catalog/CatalogSearch.tsx
+++ b/frontend/src/components/catalog/CatalogSearch.tsx
@@ -23,7 +23,7 @@ export function CatalogSearch({ allTags }: CatalogSearchProps) {
         placeholder="Search courses..."
         value={search}
         onChange={(e) => setSearch(e.target.value)}
-        className="max-w-sm"
+        className="w-full sm:max-w-sm"
       />
       {allTags.length > 0 && (
         <div className="flex flex-wrap gap-2">

--- a/frontend/src/components/course/LessonSidebar.tsx
+++ b/frontend/src/components/course/LessonSidebar.tsx
@@ -6,9 +6,10 @@ import type { CourseResponse } from '@/api/types';
 
 interface LessonSidebarProps {
   course: CourseResponse;
+  onNavigate?: () => void;
 }
 
-export function LessonSidebar({ course }: LessonSidebarProps) {
+export function LessonSidebar({ course, onNavigate }: LessonSidebarProps) {
   const navigate = useNavigate();
   const completed = course.lessons.filter((l) => l.status === 'completed').length;
   const allCompleted = completed === course.lessons.length && course.lessons.length > 0;
@@ -22,6 +23,7 @@ export function LessonSidebar({ course }: LessonSidebarProps) {
           <NavLink
             key={lesson.id}
             to={`/courses/${course.id}/lessons/${i}`}
+            onClick={() => onNavigate?.()}
             className={({ isActive }) =>
               cn(
                 'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
@@ -48,7 +50,10 @@ export function LessonSidebar({ course }: LessonSidebarProps) {
         <Button
           variant="outline"
           className="w-full"
-          onClick={() => navigate(`/courses/${course.id}/assessment`)}
+          onClick={() => {
+            onNavigate?.();
+            navigate(`/courses/${course.id}/assessment`);
+          }}
         >
           Take Assessment
         </Button>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -5,7 +5,7 @@ export function AppShell() {
   return (
     <div className="min-h-screen bg-background">
       <NavBar />
-      <main className="mx-auto max-w-6xl px-4 py-6">
+      <main className="mx-auto max-w-6xl px-4 py-4 sm:py-6">
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { Menu, LogOut, Settings } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuthStore } from '@/stores/auth-store';
-import { LogOut, Settings } from 'lucide-react';
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 
 const NAV_ITEMS = [
   { to: '/catalog', label: 'Catalog' },
@@ -12,6 +14,7 @@ const NAV_ITEMS = [
 export function NavBar() {
   const location = useLocation();
   const { user, logout } = useAuthStore();
+  const [open, setOpen] = useState(false);
 
   return (
     <header className="border-b bg-white">
@@ -19,7 +22,9 @@ export function NavBar() {
         <Link to="/catalog" className="text-lg font-bold tracking-tight">
           1111 School
         </Link>
-        <nav className="flex gap-4">
+
+        {/* Desktop nav — hidden on mobile */}
+        <nav className="hidden sm:flex gap-4">
           {NAV_ITEMS.map(({ to, label }) => (
             <Link
               key={to}
@@ -36,7 +41,8 @@ export function NavBar() {
           ))}
         </nav>
 
-        <div className="ml-auto flex items-center gap-3">
+        {/* Desktop right-side controls — hidden on mobile */}
+        <div className="ml-auto hidden sm:flex items-center gap-3">
           {user && (
             <span className="text-sm text-muted-foreground">{user.email}</span>
           )}
@@ -59,6 +65,65 @@ export function NavBar() {
             <LogOut className="h-4 w-4" />
             Log out
           </button>
+        </div>
+
+        {/* Mobile hamburger — visible on mobile only */}
+        <div className="ml-auto sm:hidden">
+          <Sheet open={open} onOpenChange={setOpen}>
+            <SheetTrigger asChild>
+              <button
+                aria-label="Open menu"
+                className="p-2 text-muted-foreground hover:text-foreground"
+              >
+                <Menu className="h-5 w-5" />
+              </button>
+            </SheetTrigger>
+            <SheetContent side="right" className="w-64 pt-10">
+              <nav className="flex flex-col gap-4 px-4">
+                {NAV_ITEMS.map(({ to, label }) => (
+                  <Link
+                    key={to}
+                    to={to}
+                    onClick={() => setOpen(false)}
+                    className={cn(
+                      'text-sm font-medium transition-colors hover:text-foreground',
+                      location.pathname.startsWith(to)
+                        ? 'text-foreground'
+                        : 'text-muted-foreground',
+                    )}
+                  >
+                    {label}
+                  </Link>
+                ))}
+                <hr className="border-border" />
+                {user && (
+                  <span className="truncate text-xs text-muted-foreground">
+                    {user.email}
+                  </span>
+                )}
+                <Link
+                  to="/settings"
+                  onClick={() => setOpen(false)}
+                  className={cn(
+                    'inline-flex items-center gap-2 text-sm font-medium transition-colors hover:text-foreground',
+                    location.pathname === '/settings'
+                      ? 'text-foreground'
+                      : 'text-muted-foreground',
+                  )}
+                >
+                  <Settings className="h-4 w-4" />
+                  Settings
+                </Link>
+                <button
+                  onClick={() => { setOpen(false); logout(); }}
+                  className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <LogOut className="h-4 w-4" />
+                  Log out
+                </button>
+              </nav>
+            </SheetContent>
+          </Sheet>
         </div>
       </div>
     </header>

--- a/frontend/src/components/lesson/MarkdownRenderer.tsx
+++ b/frontend/src/components/lesson/MarkdownRenderer.tsx
@@ -8,7 +8,7 @@ interface MarkdownRendererProps {
 
 export function MarkdownRenderer({ content }: MarkdownRendererProps) {
   return (
-    <div className="prose prose-neutral max-w-none">
+    <div className="prose prose-neutral prose-sm sm:prose-base max-w-none">
       <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
         {content}
       </Markdown>

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-4 sm:gap-6 rounded-xl border py-4 sm:py-6 shadow-sm",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          side === "right" &&
+            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          side === "left" &&
+            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          side === "top" &&
+            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+          side === "bottom" &&
+            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -140,7 +140,7 @@ export function ActivityPage() {
             improvements={displayFeedback.improvements}
             tips={displayFeedback.tips}
           />
-          <div className="flex gap-3">
+          <div className="flex flex-wrap gap-3">
             {passed ? (
               <Button onClick={handleContinue}>
                 {isLast ? 'Take Assessment' : 'Continue'}

--- a/frontend/src/pages/AgentLogsPage.tsx
+++ b/frontend/src/pages/AgentLogsPage.tsx
@@ -51,13 +51,13 @@ function AgentLogRow({ log, courseLabel }: { log: AgentLog; courseLabel: string 
     <div className="border rounded-lg overflow-hidden">
       <button
         onClick={() => setExpanded((v) => !v)}
-        className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-muted/40 transition-colors"
+        className="w-full flex flex-wrap items-center gap-3 px-3 sm:px-4 py-3 text-left hover:bg-muted/40 transition-colors"
       >
         <span className="text-muted-foreground shrink-0">
           {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
         </span>
 
-        <span className="font-mono text-sm font-medium w-44 shrink-0">{log.agent_name}</span>
+        <span className="font-mono text-sm font-medium w-32 sm:w-44 shrink-0 truncate">{log.agent_name}</span>
 
         <span
           className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
@@ -70,23 +70,23 @@ function AgentLogRow({ log, courseLabel }: { log: AgentLog; courseLabel: string 
         <span className="text-sm text-muted-foreground shrink-0 hidden sm:block">{timestamp}</span>
 
         {log.duration_ms != null && (
-          <span className="text-sm text-muted-foreground shrink-0">
+          <span className="text-sm text-muted-foreground shrink-0 hidden sm:block">
             {log.duration_ms >= 1000 ? `${(log.duration_ms / 1000).toFixed(1)}s` : `${log.duration_ms}ms`}
           </span>
         )}
 
         {(log.input_tokens != null || log.output_tokens != null) && (
-          <span className="text-sm text-muted-foreground shrink-0">
+          <span className="text-sm text-muted-foreground shrink-0 hidden md:block">
             in={log.input_tokens ?? '—'} out={log.output_tokens ?? '—'}
           </span>
         )}
 
-        <span className="text-xs text-muted-foreground shrink-0 truncate max-w-[160px]">
+        <span className="text-xs text-muted-foreground shrink-0 truncate max-w-[160px] hidden md:block">
           {courseLabel}
         </span>
 
         {cost != null && (
-          <span className="text-sm text-muted-foreground shrink-0 ml-auto">
+          <span className="text-sm text-muted-foreground shrink-0 ml-auto hidden sm:block">
             ${cost.toFixed(4)}
           </span>
         )}
@@ -211,7 +211,7 @@ export function AgentLogsPage() {
       {/* Header */}
       <div className="flex items-baseline justify-between">
         <div>
-          <h1 className="text-2xl font-bold">Agent Logs</h1>
+          <h1 className="text-xl sm:text-2xl font-bold">Agent Logs</h1>
           <p className="text-sm text-muted-foreground mt-1">
             {isFiltered ? `${filtered.length} of ${logs.length}` : logs.length} calls
           </p>

--- a/frontend/src/pages/AssessmentPage.tsx
+++ b/frontend/src/pages/AssessmentPage.tsx
@@ -185,9 +185,9 @@ export function AssessmentPage() {
   if (assessment?.status === 'reviewed') {
     return (
       <div className="mx-auto max-w-2xl space-y-6">
-        <h1 className="text-2xl font-bold">Assessment Results</h1>
+        <h1 className="text-xl sm:text-2xl font-bold">Assessment Results</h1>
         <AssessmentResults assessment={assessment} />
-        <div className="flex gap-3">
+        <div className="flex flex-wrap gap-3">
           {assessment.passed ? (
             <Button onClick={() => navigate('/my-courses')}>
               Back to My Courses
@@ -204,7 +204,7 @@ export function AssessmentPage() {
   if (reviewing) {
     return (
       <div className="mx-auto max-w-2xl space-y-6">
-        <h1 className="text-2xl font-bold">Assessment</h1>
+        <h1 className="text-xl sm:text-2xl font-bold">Assessment</h1>
         <div className="flex items-center gap-3 text-muted-foreground">
           <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
           Reviewing your assessment...
@@ -218,7 +218,7 @@ export function AssessmentPage() {
   if (assessment?.assessment_spec && assessment.status === 'pending') {
     return (
       <div className="mx-auto max-w-2xl space-y-6">
-        <h1 className="text-2xl font-bold">Assessment</h1>
+        <h1 className="text-xl sm:text-2xl font-bold">Assessment</h1>
         <AssessmentForm
           spec={assessment.assessment_spec}
           onSubmit={handleSubmit}

--- a/frontend/src/pages/CatalogPage.tsx
+++ b/frontend/src/pages/CatalogPage.tsx
@@ -18,7 +18,7 @@ export function CatalogPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold">Course Catalog</h1>
+        <h1 className="text-xl sm:text-2xl font-bold">Course Catalog</h1>
         <p className="text-muted-foreground">
           Browse courses or create your own
         </p>

--- a/frontend/src/pages/CoursePage.tsx
+++ b/frontend/src/pages/CoursePage.tsx
@@ -1,13 +1,17 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, Outlet, useNavigate, useLocation } from 'react-router-dom';
+import { Menu } from 'lucide-react';
 import { useCourseStore } from '@/stores/course-store';
 import { LessonSidebar } from '@/components/course/LessonSidebar';
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 
 export function CoursePage() {
   const { courseId } = useParams<{ courseId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
   const { course, courseLoading: loading, loadCourse } = useCourseStore();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   useEffect(() => {
     if (courseId) loadCourse(courseId);
@@ -32,8 +36,29 @@ export function CoursePage() {
 
   return (
     <div className="flex gap-6">
-      <LessonSidebar course={course} />
+      {/* Persistent sidebar — hidden on mobile */}
+      <div className="hidden sm:block">
+        <LessonSidebar course={course} />
+      </div>
+
       <div className="min-w-0 flex-1">
+        {/* Mobile sidebar trigger — visible on mobile only */}
+        <div className="mb-4 sm:hidden">
+          <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+            <SheetTrigger asChild>
+              <Button variant="outline" size="sm" className="gap-2">
+                <Menu className="h-4 w-4" />
+                Lessons
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" className="w-72 pt-10">
+              <LessonSidebar
+                course={course}
+                onNavigate={() => setSidebarOpen(false)}
+              />
+            </SheetContent>
+          </Sheet>
+        </div>
         <Outlet />
       </div>
     </div>

--- a/frontend/src/pages/MyCoursesPage.tsx
+++ b/frontend/src/pages/MyCoursesPage.tsx
@@ -13,7 +13,7 @@ export function MyCoursesPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold">My Courses</h1>
+        <h1 className="text-xl sm:text-2xl font-bold">My Courses</h1>
         <p className="text-muted-foreground">
           Track your learning progress
         </p>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -86,7 +86,7 @@ export function SettingsPage() {
 
   return (
     <div className="mx-auto max-w-xl space-y-6">
-      <h1 className="text-2xl font-bold">Profile Settings</h1>
+      <h1 className="text-xl sm:text-2xl font-bold">Profile Settings</h1>
 
       <form onSubmit={handleSave} className="space-y-4">
         <div className="space-y-1">


### PR DESCRIPTION
## Summary
- **NavBar**: hamburger menu on mobile (`sm:hidden`) with Sheet drawer containing all nav links, email, settings, and logout; full inline nav on `sm+`
- **CoursePage + LessonSidebar**: sidebar hidden on mobile, replaced by a \"Lessons\" Sheet drawer triggered by a button; `onNavigate` prop closes it on navigation
- **AgentLogsPage**: progressive column disclosure — chevron + agent name + badge always visible; timestamp/duration/cost at `sm+`; tokens/course at `md+`
- **MarkdownRenderer**: responsive prose sizing (`prose-sm` mobile, `prose-base` sm+)
- **AssessmentResults**: score `text-2xl sm:text-4xl`, flex container wraps on mobile
- **FeedbackDisplay**: score `text-2xl sm:text-3xl`, padding `p-3 sm:p-4`
- **ActivityPage + AssessmentPage**: button rows use `flex-wrap` to stack on narrow screens
- **Card component**: `gap-4 sm:gap-6 py-4 sm:py-6` — scales down on mobile
- **CatalogSearch**: input `w-full sm:max-w-sm` (was overflowing 375px viewports)
- **AppShell**: `py-4 sm:py-6`
- **Page headings**: `text-xl sm:text-2xl` across all pages (Catalog, My Courses, Assessment, Settings, Agent Logs)

No new packages — Sheet uses `@radix-ui/react-dialog` which was already installed.

## Test plan
- [ ] DevTools device toolbar: iPhone SE (375px), iPhone 14 (390px), iPad (768px)
- [ ] NavBar hamburger opens/closes; links close the sheet and navigate correctly
- [ ] Course page shows "Lessons" button on mobile; Sheet opens and closes on nav
- [ ] Agent Logs rows don't cause horizontal scroll on mobile
- [ ] Catalog search input doesn't overflow on 375px
- [ ] Lesson markdown readable on mobile
- [ ] Assessment/activity score + buttons don't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)