### PR TITLE
Accessibility improvements for screen reader and low-vision users

### DIFF
--- a/frontend/src/components/activity/ActivityPanel.tsx
+++ b/frontend/src/components/activity/ActivityPanel.tsx
@@ -26,13 +26,15 @@ export function ActivityPanel({ spec }: ActivityPanelProps) {
         <div>
           <button
             type="button"
+            aria-expanded={showHints}
+            aria-controls="hints-list"
             onClick={() => setShowHints(!showHints)}
             className="text-sm font-medium text-primary hover:underline"
           >
             {showHints ? 'Hide Hints' : 'Show Hints'}
           </button>
           {showHints && (
-            <ul className="mt-2 ml-4 list-disc text-sm text-muted-foreground">
+            <ul id="hints-list" className="mt-2 ml-4 list-disc text-sm text-muted-foreground">
               {spec.hints.map((h, i) => (
                 <li key={i}>{h}</li>
               ))}

--- a/frontend/src/components/activity/SubmissionForm.tsx
+++ b/frontend/src/components/activity/SubmissionForm.tsx
@@ -23,14 +23,23 @@ export function SubmissionForm({ onSubmit }: SubmissionFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-3">
+      <label htmlFor="activity-response" className="sr-only">
+        Your response
+      </label>
       <Textarea
+        id="activity-response"
         placeholder="Type your response..."
         value={text}
         onChange={(e) => setText(e.target.value)}
         rows={6}
         disabled={submitting}
+        aria-label="Your response"
       />
-      <Button type="submit" disabled={submitting || !text.trim()}>
+      <Button
+        type="submit"
+        disabled={submitting || !text.trim()}
+        aria-busy={submitting}
+      >
         {submitting ? 'Submitting...' : 'Submit'}
       </Button>
     </form>

--- a/frontend/src/components/assessment/AssessmentForm.tsx
+++ b/frontend/src/components/assessment/AssessmentForm.tsx
@@ -41,22 +41,24 @@ export function AssessmentForm({ spec, onSubmit }: AssessmentFormProps) {
       <h2 className="text-lg font-semibold">{spec.assessment_title}</h2>
       {spec.items.map((item, i) => (
         <div key={i} className="space-y-2">
-          <p className="text-sm font-medium">
+          <label htmlFor={`assessment-answer-${i}`} className="text-sm font-medium">
             {i + 1}. {item.objective}
-          </p>
+          </label>
           <div className="rounded-md bg-muted p-3">
             <p className="text-sm">{item.prompt}</p>
           </div>
           <Textarea
+            id={`assessment-answer-${i}`}
             placeholder="Your answer..."
             value={answers[i] ?? ''}
             onChange={(e) => update(i, e.target.value)}
             rows={4}
             disabled={submitting}
+            aria-label={`Answer for: ${item.objective}`}
           />
         </div>
       ))}
-      <Button type="submit" disabled={submitting || !allFilled} className="w-full">
+      <Button type="submit" disabled={submitting || !allFilled} aria-busy={submitting} className="w-full">
         {submitting ? 'Submitting...' : 'Submit Assessment'}
       </Button>
     </form>

--- a/frontend/src/components/course/LessonSidebar.tsx
+++ b/frontend/src/components/course/LessonSidebar.tsx
@@ -18,12 +18,14 @@ export function LessonSidebar({ course, onNavigate }: LessonSidebarProps) {
     <aside className="w-64 shrink-0 space-y-4">
       <ProgressBar completed={completed} total={course.lessons.length} />
 
-      <nav className="space-y-1">
+      <nav aria-label="Course lessons" className="space-y-1">
         {course.lessons.map((lesson, i) => (
           <NavLink
             key={lesson.id}
             to={`/courses/${course.id}/lessons/${i}`}
             onClick={() => onNavigate?.()}
+            aria-disabled={lesson.status === 'locked' ? 'true' : undefined}
+            aria-label={`Lesson ${i + 1}${lesson.status === 'completed' ? ', completed' : lesson.status === 'locked' ? ', locked' : ''}`}
             className={({ isActive }) =>
               cn(
                 'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
@@ -34,7 +36,7 @@ export function LessonSidebar({ course, onNavigate }: LessonSidebarProps) {
               )
             }
           >
-            <span className="text-xs">
+            <span aria-hidden="true" className="text-xs">
               {lesson.status === 'completed'
                 ? '✓'
                 : lesson.status === 'locked'

--- a/frontend/src/components/generation/GenerationStepper.tsx
+++ b/frontend/src/components/generation/GenerationStepper.tsx
@@ -32,7 +32,7 @@ export function GenerationStepper({ objectives, progress, generating }: Generati
   }
 
   return (
-    <div className="space-y-0">
+    <ol aria-label="Generation progress" className="space-y-0">
       {indices.map((i) => (
         <StepperItem
           key={i}
@@ -42,6 +42,6 @@ export function GenerationStepper({ objectives, progress, generating }: Generati
           inferActive={i === inferredActiveIndex}
         />
       ))}
-    </div>
+    </ol>
   );
 }

--- a/frontend/src/components/generation/StepperItem.tsx
+++ b/frontend/src/components/generation/StepperItem.tsx
@@ -12,18 +12,18 @@ interface StepperItemProps {
 function StepIcon({ done, active }: { done: boolean; active: boolean }) {
   if (done)
     return (
-      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-green-500 text-xs text-white">
+      <span aria-hidden="true" className="flex h-6 w-6 items-center justify-center rounded-full bg-green-500 text-xs text-white">
         &#10003;
       </span>
     );
   if (active)
     return (
-      <span className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-primary">
+      <span aria-hidden="true" className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-primary">
         <span className="h-2 w-2 animate-pulse rounded-full bg-primary" />
       </span>
     );
   return (
-    <span className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-muted-foreground/30" />
+    <span aria-hidden="true" className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-muted-foreground/30" />
   );
 }
 
@@ -35,7 +35,7 @@ export function StepperItem({ index, objectiveLabel, progress, inferActive }: St
   // On-demand: not yet started and not the currently active objective
   if (!anyStarted && !inferActive) {
     return (
-      <div className="flex gap-3">
+      <li className="flex gap-3 list-none">
         <div className="flex flex-col items-center">
           <StepIcon done={false} active={false} />
           <div className="w-px flex-1 bg-border" />
@@ -48,7 +48,7 @@ export function StepperItem({ index, objectiveLabel, progress, inferActive }: St
             Generates when you reach this lesson
           </p>
         </div>
-      </div>
+      </li>
     );
   }
 
@@ -63,7 +63,7 @@ export function StepperItem({ index, objectiveLabel, progress, inferActive }: St
   const isActive = anyStarted || !!inferActive;
 
   return (
-    <div className="flex gap-3">
+    <li className="flex gap-3 list-none">
       <div className="flex flex-col items-center">
         <StepIcon done={allDone} active={isActive && !allDone} />
         <div className="w-px flex-1 bg-border" />
@@ -71,27 +71,29 @@ export function StepperItem({ index, objectiveLabel, progress, inferActive }: St
       <div className="pb-6">
         <p className={cn('text-sm font-medium', allDone && 'text-green-700')}>
           Objective {index + 1}: {objectiveLabel}
+          {allDone && <span className="sr-only"> (complete)</span>}
+          {isActive && !allDone && <span className="sr-only"> (in progress)</span>}
         </p>
         {p.error && (
-          <p className="mt-1 text-xs text-destructive">{p.error}</p>
+          <p role="alert" className="mt-1 text-xs text-destructive">{p.error}</p>
         )}
         <div className="mt-2 space-y-1">
           {steps.map((step, i) => (
             <div key={i} className="flex items-center gap-2 text-xs text-muted-foreground">
               {step.done ? (
-                <span className="text-green-600">&#10003;</span>
+                <span aria-hidden="true" className="text-green-600">&#10003;</span>
               ) : isActive && !steps.slice(0, i).every((s) => s.done) ? (
-                <span className="text-muted-foreground/40">&#9675;</span>
+                <span aria-hidden="true" className="text-muted-foreground/40">&#9675;</span>
               ) : isActive ? (
-                <span className="animate-spin text-primary">&#9696;</span>
+                <span aria-hidden="true" className="animate-spin text-primary">&#9696;</span>
               ) : (
-                <span className="text-muted-foreground/40">&#9675;</span>
+                <span aria-hidden="true" className="text-muted-foreground/40">&#9675;</span>
               )}
-              <span>{step.label}</span>
+              <span>{step.label}{step.done && <span className="sr-only"> done</span>}</span>
             </div>
           ))}
         </div>
       </div>
-    </div>
+    </li>
   );
 }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [aria-busy=true]:opacity-100 [aria-busy=true]:cursor-wait [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -126,8 +126,8 @@ export function ActivityPage() {
       <ActivityPanel spec={activity.activity_spec} />
 
       {reviewing ? (
-        <div className="flex items-center gap-3 text-muted-foreground">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+        <div role="status" aria-live="polite" className="flex items-center gap-3 text-muted-foreground">
+          <div aria-hidden="true" className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
           Reviewing your submission...
         </div>
       ) : displayFeedback ? (
@@ -161,7 +161,7 @@ export function ActivityPage() {
       ) : (
         <>
           <SubmissionForm onSubmit={handleSubmit} />
-          {error && <p className="text-sm text-destructive">{error}</p>}
+          {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
         </>
       )}
     </div>

--- a/frontend/src/pages/AssessmentPage.tsx
+++ b/frontend/src/pages/AssessmentPage.tsx
@@ -205,11 +205,11 @@ export function AssessmentPage() {
     return (
       <div className="mx-auto max-w-2xl space-y-6">
         <h1 className="text-xl sm:text-2xl font-bold">Assessment</h1>
-        <div className="flex items-center gap-3 text-muted-foreground">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+        <div role="status" aria-live="polite" className="flex items-center gap-3 text-muted-foreground">
+          <div aria-hidden="true" className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
           Reviewing your assessment...
         </div>
-        {error && <p className="text-sm text-destructive">{error}</p>}
+        {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
       </div>
     );
   }
@@ -223,7 +223,7 @@ export function AssessmentPage() {
           spec={assessment.assessment_spec}
           onSubmit={handleSubmit}
         />
-        {error && <p className="text-sm text-destructive">{error}</p>}
+        {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
       </div>
     );
   }
@@ -238,8 +238,8 @@ export function AssessmentPage() {
           : 'Ready to test your knowledge?'}
       </p>
       {generating && (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <span className="animate-spin">&#9696;</span>
+        <div role="status" aria-live="polite" className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span aria-hidden="true" className="animate-spin">&#9696;</span>
           <span>This may take a few seconds</span>
         </div>
       )}
@@ -247,7 +247,7 @@ export function AssessmentPage() {
         <Button onClick={handleGenerate}>Generate Assessment</Button>
       )}
       {error && (
-        <div className="space-y-2">
+        <div role="alert" className="space-y-2">
           <p className="text-sm text-destructive">{error}</p>
           <Button variant="outline" onClick={handleGenerate}>
             Retry

--- a/frontend/src/pages/GenerationPage.tsx
+++ b/frontend/src/pages/GenerationPage.tsx
@@ -67,7 +67,7 @@ export function GenerationPage() {
       <div className="mx-auto max-w-2xl space-y-6">
         <div>
           <h1 className="text-2xl font-bold">Generating Your Course</h1>
-          <p className="text-muted-foreground">Loading course details...</p>
+          <p role="status" aria-live="polite" className="text-muted-foreground">Loading course details...</p>
         </div>
       </div>
     );
@@ -98,7 +98,7 @@ export function GenerationPage() {
     <div className="mx-auto max-w-2xl space-y-6">
       <div>
         <h1 className="text-2xl font-bold">{heading}</h1>
-        <p className="text-muted-foreground">{subtitle}</p>
+        <p aria-live="polite" className="text-muted-foreground">{subtitle}</p>
       </div>
 
       {(objectives.length > 0 || progress.size > 0) && !isZombie && (
@@ -112,7 +112,7 @@ export function GenerationPage() {
             generating the course or go back to your courses.
           </p>
           <div className="mt-3 flex gap-2">
-            <Button variant="outline" size="sm" onClick={handleRetry} disabled={retrying}>
+            <Button variant="outline" size="sm" onClick={handleRetry} disabled={retrying} aria-busy={retrying}>
               {retrying ? 'Retrying...' : 'Retry Generation'}
             </Button>
             <Button

--- a/frontend/src/pages/LessonPage.tsx
+++ b/frontend/src/pages/LessonPage.tsx
@@ -38,8 +38,8 @@ export function LessonPage() {
       {lesson.lesson_content ? (
         <MarkdownRenderer content={lesson.lesson_content} />
       ) : (
-        <div className="flex items-center gap-3 text-muted-foreground">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+        <div role="status" aria-live="polite" className="flex items-center gap-3 text-muted-foreground">
+          <div aria-hidden="true" className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
           Generating lesson content...
         </div>
       )}


### PR DESCRIPTION
## Summary
- **Loading buttons stay visible when busy**: `[aria-busy=true]:opacity-100` added to `Button` component so "Submitting…" / "Retrying…" buttons no longer dim to 50% opacity — directly fixes the reported "light-colored wait button" issue
- **Screen reader announcements for loading states**: all spinners wrapped in `role="status" aria-live="polite"`; decorative spinner elements marked `aria-hidden="true"`
- **Instant error announcements**: error messages get `role="alert"` so screen readers announce them immediately without focus change
- **Form labels**: `SubmissionForm` textarea linked via `<label>`/`id`; `AssessmentForm` answer textareas labelled with their objective text
- **LessonSidebar**: `<nav aria-label="Course lessons">`, locked items get `aria-disabled="true"`, status icons (`✓`, `🔒`, `○`) marked `aria-hidden` with status baked into the link's `aria-label`
- **GenerationStepper**: changed to `<ol aria-label="Generation progress">` / `<li>` for proper list semantics; step icons `aria-hidden`, screen-reader-only status text added
- **ActivityPanel hints**: toggle button gets `aria-expanded` + `aria-controls` so screen readers announce expand/collapse state

## Test plan
- [ ] Submit an activity response and confirm the "Submitting…" button is visually prominent (no dimming)
- [ ] Use a screen reader (VoiceOver / NVDA) and confirm loading states are announced on Lesson, Activity, and Assessment pages
- [ ] Confirm error messages are announced immediately when they appear
- [ ] Tab through the LessonSidebar and verify locked lessons are announced as "locked"
- [ ] Open the activity hints and confirm VoiceOver announces "Show Hints, collapsed / expanded"
- [ ] Navigate the generation page and verify the stepper is read as a list with progress status

🤖 Generated with [Claude Code](https://claude.com/claude-code)