### PR TITLE
Replace mobile side-sliding navigation with dropdown and bottom sheet

### DIFF
--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -1,9 +1,8 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Menu, LogOut, Settings } from 'lucide-react';
+import { Menu, X, LogOut, Settings } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuthStore } from '@/stores/auth-store';
-import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { Logo } from '@/components/layout/Logo';
 
 const NAV_ITEMS = [
@@ -15,9 +14,27 @@ export function NavBar() {
   const location = useLocation();
   const { user, logout } = useAuthStore();
   const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close menu on route change
+  useEffect(() => {
+    setOpen(false);
+  }, [location.pathname]);
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
 
   return (
-    <header className="border-b bg-white">
+    <header className="border-b bg-white" ref={menuRef}>
       <div className="mx-auto flex h-14 max-w-6xl items-center gap-6 px-4">
         <Link to="/courses" aria-label="1111 home">
           <Logo className="h-7 w-7" />
@@ -65,64 +82,65 @@ export function NavBar() {
           </button>
         </div>
 
-        <div className="ml-auto sm:hidden">
-          <Sheet open={open} onOpenChange={setOpen}>
-            <SheetTrigger asChild>
-              <button
-                aria-label="Open menu"
-                className="p-2 text-muted-foreground hover:text-foreground"
-              >
-                <Menu className="h-5 w-5" />
-              </button>
-            </SheetTrigger>
-            <SheetContent side="right" className="w-64 pt-10">
-              <nav className="flex flex-col gap-4 px-4" aria-label="Mobile navigation">
-                {NAV_ITEMS.map(({ to, label }) => (
-                  <Link
-                    key={to}
-                    to={to}
-                    onClick={() => setOpen(false)}
-                    className={cn(
-                      'text-sm font-medium transition-colors hover:text-foreground',
-                      location.pathname.startsWith(to)
-                        ? 'text-foreground'
-                        : 'text-muted-foreground',
-                    )}
-                  >
-                    {label}
-                  </Link>
-                ))}
-                <hr className="border-border" />
-                {user && (
-                  <span className="truncate text-xs text-muted-foreground">
-                    {user.email}
-                  </span>
-                )}
-                <Link
-                  to="/settings"
-                  onClick={() => setOpen(false)}
-                  className={cn(
-                    'inline-flex items-center gap-2 text-sm font-medium transition-colors hover:text-foreground',
-                    location.pathname === '/settings'
-                      ? 'text-foreground'
-                      : 'text-muted-foreground',
-                  )}
-                >
-                  <Settings className="h-4 w-4" />
-                  Settings
-                </Link>
-                <button
-                  onClick={() => { setOpen(false); logout(); }}
-                  className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <LogOut className="h-4 w-4" />
-                  Log out
-                </button>
-              </nav>
-            </SheetContent>
-          </Sheet>
-        </div>
+        <button
+          className="ml-auto p-2 text-muted-foreground hover:text-foreground sm:hidden"
+          onClick={() => setOpen((v) => !v)}
+          aria-label={open ? 'Close menu' : 'Open menu'}
+          aria-expanded={open}
+        >
+          {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+        </button>
       </div>
+
+      {/* Mobile dropdown menu */}
+      {open && (
+        <nav
+          className="border-t bg-white px-4 pb-4 pt-3 sm:hidden"
+          aria-label="Mobile navigation"
+        >
+          <div className="mx-auto flex max-w-6xl flex-col gap-3">
+            {NAV_ITEMS.map(({ to, label }) => (
+              <Link
+                key={to}
+                to={to}
+                className={cn(
+                  'text-sm font-medium transition-colors hover:text-foreground',
+                  location.pathname.startsWith(to)
+                    ? 'text-foreground'
+                    : 'text-muted-foreground',
+                )}
+              >
+                {label}
+              </Link>
+            ))}
+            <hr className="border-border" />
+            {user && (
+              <span className="truncate text-xs text-muted-foreground">
+                {user.email}
+              </span>
+            )}
+            <Link
+              to="/settings"
+              className={cn(
+                'inline-flex items-center gap-2 text-sm font-medium transition-colors hover:text-foreground',
+                location.pathname === '/settings'
+                  ? 'text-foreground'
+                  : 'text-muted-foreground',
+              )}
+            >
+              <Settings className="h-4 w-4" />
+              Settings
+            </Link>
+            <button
+              onClick={() => { setOpen(false); logout(); }}
+              className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <LogOut className="h-4 w-4" />
+              Log out
+            </button>
+          </div>
+        </nav>
+      )}
     </header>
   );
 }

--- a/frontend/src/pages/CoursePage.tsx
+++ b/frontend/src/pages/CoursePage.tsx
@@ -51,7 +51,7 @@ export function CoursePage() {
                 Lessons
               </Button>
             </SheetTrigger>
-            <SheetContent side="left" className="w-72 pt-10">
+            <SheetContent side="bottom" className="max-h-[70vh] overflow-y-auto pt-6">
               <LessonSidebar
                 course={course}
                 onNavigate={() => setSidebarOpen(false)}


### PR DESCRIPTION
NavBar: Replace the right-side slide-out Sheet with an inline dropdown panel that expands below the header. Toggles between Menu/X icons and closes on route change or outside click.

CoursePage: Switch lesson sidebar from left-side sheet to bottom sheet for a more natural mobile feel.

https://claude.ai/code/session_01YD7Heo45PUu15WFS2PKQeL