### PR TITLE
Make LessonSidebar full-width in mobile bottom sheet

### DIFF
--- a/frontend/src/components/course/LessonSidebar.tsx
+++ b/frontend/src/components/course/LessonSidebar.tsx
@@ -10,9 +10,10 @@ import { useLessonNavStore } from '@/stores/lesson-nav-store';
 interface LessonSidebarProps {
   course: CourseResponse;
   onNavigate?: () => void;
+  className?: string;
 }
 
-export function LessonSidebar({ course, onNavigate }: LessonSidebarProps) {
+export function LessonSidebar({ course, onNavigate, className }: LessonSidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const { sections, currentPage, setCurrentPage } = useLessonNavStore();
@@ -31,7 +32,7 @@ export function LessonSidebar({ course, onNavigate }: LessonSidebarProps) {
   const allDone = completed === totalLessons && totalLessons > 0;
 
   return (
-    <aside className="w-64 shrink-0 space-y-4" aria-label="Course navigation">
+    <aside className={cn("w-64 shrink-0 space-y-4", className)} aria-label="Course navigation">
       {course.professional_role && (
         <div className="rounded-md bg-primary/10 px-3 py-2 text-xs">
           <span className="font-medium">Role:</span>{' '}

--- a/frontend/src/pages/CoursePage.tsx
+++ b/frontend/src/pages/CoursePage.tsx
@@ -55,6 +55,7 @@ export function CoursePage() {
               <LessonSidebar
                 course={course}
                 onNavigate={() => setSidebarOpen(false)}
+                className="w-full"
               />
             </SheetContent>
           </Sheet>


### PR DESCRIPTION
Add className prop to LessonSidebar so CoursePage can override the fixed w-64 width when rendering inside the mobile bottom sheet.

https://claude.ai/code/session_01YD7Heo45PUu15WFS2PKQeL