### PR TITLE
Fix mobile lesson nav taking only w-64 in bottom sheet

### DIFF
--- a/frontend/src/components/course/LessonSidebar.tsx
+++ b/frontend/src/components/course/LessonSidebar.tsx
@@ -32,7 +32,7 @@ export function LessonSidebar({ course, onNavigate, className }: LessonSidebarPr
   const allDone = completed === totalLessons && totalLessons > 0;
 
   return (
-    <aside className={cn("w-64 shrink-0 space-y-4", className)} aria-label="Course navigation">
+    <aside className={cn("shrink-0 space-y-4", className)} aria-label="Course navigation">
       {course.professional_role && (
         <div className="rounded-md bg-primary/10 px-3 py-2 text-xs">
           <span className="font-medium">Role:</span>{' '}

--- a/frontend/src/pages/CoursePage.tsx
+++ b/frontend/src/pages/CoursePage.tsx
@@ -38,7 +38,7 @@ export function CoursePage() {
     <div className="flex gap-6">
       {/* Persistent sidebar — hidden on mobile */}
       <div className="hidden sm:block">
-        <LessonSidebar course={course} />
+        <LessonSidebar course={course} className="w-64" />
       </div>
 
       <div className="min-w-0 flex-1">


### PR DESCRIPTION
Move w-64 width out of LessonSidebar into callers so the mobile bottom sheet gets w-full and the desktop sidebar keeps w-64.

https://claude.ai/code/session_01YD7Heo45PUu15WFS2PKQeL