### PR TITLE
Fix mobile lesson nav: full-width with text wrapping

### DIFF
--- a/frontend/src/components/course/LessonSidebar.tsx
+++ b/frontend/src/components/course/LessonSidebar.tsx
@@ -32,7 +32,7 @@ export function LessonSidebar({ course, onNavigate, className }: LessonSidebarPr
   const allDone = completed === totalLessons && totalLessons > 0;
 
   return (
-    <aside className={cn("shrink-0 space-y-4", className)} aria-label="Course navigation">
+    <aside className={cn("space-y-4", className)} aria-label="Course navigation">
       {course.professional_role && (
         <div className="rounded-md bg-primary/10 px-3 py-2 text-xs">
           <span className="font-medium">Role:</span>{' '}
@@ -91,7 +91,7 @@ export function LessonSidebar({ course, onNavigate, className }: LessonSidebarPr
                   ) : (
                     <Circle className="h-3.5 w-3.5 shrink-0" />
                   )}
-                  <span className="truncate flex-1">{title}</span>
+                  <span className="flex-1 min-w-0">{title}</span>
                   {totalActivities > 0 && !isLocked && (
                     <span className="text-[10px] text-muted-foreground tabular-nums">
                       {completedActivities}/{totalActivities}
@@ -126,7 +126,7 @@ export function LessonSidebar({ course, onNavigate, className }: LessonSidebarPr
                                 currentPage === si && !onActivityPage && 'text-primary',
                               )}
                             />
-                            <span className="truncate">
+                            <span className="min-w-0">
                               {section.title || `Section ${si + 1}`}
                             </span>
                           </button>

--- a/frontend/src/pages/CoursePage.tsx
+++ b/frontend/src/pages/CoursePage.tsx
@@ -38,7 +38,7 @@ export function CoursePage() {
     <div className="flex gap-6">
       {/* Persistent sidebar — hidden on mobile */}
       <div className="hidden sm:block">
-        <LessonSidebar course={course} className="w-64" />
+        <LessonSidebar course={course} className="w-64 shrink-0" />
       </div>
 
       <div className="min-w-0 flex-1">
@@ -51,7 +51,7 @@ export function CoursePage() {
                 Lessons
               </Button>
             </SheetTrigger>
-            <SheetContent side="bottom" className="max-h-[70vh] overflow-y-auto pt-6">
+            <SheetContent side="bottom" className="max-h-[70vh] overflow-y-auto overflow-x-hidden px-4 pt-6">
               <LessonSidebar
                 course={course}
                 onNavigate={() => setSidebarOpen(false)}


### PR DESCRIPTION
- Remove truncate from lesson titles and section names so long text wraps to multiple lines instead of being clipped
- Add overflow-x-hidden and horizontal padding to bottom sheet
- Move shrink-0 to desktop-only caller so mobile aside fills screen

https://claude.ai/code/session_01YD7Heo45PUu15WFS2PKQeL